### PR TITLE
Improved fetching notes logic

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A6620E38274C819300C708A2 /* CanvasDelegateBridgeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E37274C819300C708A2 /* CanvasDelegateBridgeObject.swift */; };
 		A6620E3A274C8FA400C708A2 /* NoteDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E39274C8FA400C708A2 /* NoteDocument.swift */; };
 		A6620E3C274CD88000C708A2 /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E3B274CD88000C708A2 /* FilePath.swift */; };
+		A688AF81276B4EEA00A034FF /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688AF80276B4EEA00A034FF /* NotificationName.swift */; };
 		A6A16EC525B1673500DF323F /* PiecesOfPaperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A16EC425B1673500DF323F /* PiecesOfPaperTests.swift */; };
 		A6CADA51276752E600657E9E /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA50276752E600657E9E /* SettingView.swift */; };
 		A6CADA532767581700657E9E /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA522767581700657E9E /* SettingViewModel.swift */; };
@@ -97,6 +98,7 @@
 		A6675A37251D89BA00343151 /* Like Paper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Like Paper.entitlements"; sourceTree = "<group>"; };
 		A66E7512253531440026B9A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A66E7513253538E00026B9A8 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
+		A688AF80276B4EEA00A034FF /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		A6A16EC225B1673500DF323F /* PiecesOfPaperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PiecesOfPaperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A16EC425B1673500DF323F /* PiecesOfPaperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiecesOfPaperTests.swift; sourceTree = "<group>"; };
 		A6A16EC625B1673500DF323F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				A63C957F275CFF7900822461 /* TagModel.swift */,
 				A63C956C275C7CF300822461 /* TagEntity.swift */,
 				A6CADA5427675D8500657E9E /* UserPreference.swift */,
+				A688AF80276B4EEA00A034FF /* NotificationName.swift */,
 				A63C95912764435200822461 /* Deperecated */,
 			);
 			path = Model;
@@ -426,6 +429,7 @@
 				A63C9578275C8F4A00822461 /* TagList.swift in Sources */,
 				A6620E272747A66100C708A2 /* CanvasRouter.swift in Sources */,
 				A62EEAF42732517600D513B8 /* NotesViewModel.swift in Sources */,
+				A688AF81276B4EEA00A034FF /* NotificationName.swift in Sources */,
 				A6484FD2272BB5CA00676ED8 /* PKCanvasViewWrapper.swift in Sources */,
 				A6484FD4272CF10800676ED8 /* UIActivityViewControllerWrapper.swift in Sources */,
 				A6EE43272523271F000B203E /* Document.swift in Sources */,

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -41,7 +41,7 @@ struct FilePath {
         return dateFormatter.string(from: Date()) + ".plist"
     }
 
-    static var tagListFileName: URL? {
+    static var tagListFileUrl: URL? {
         libraryUrl?.appendingPathComponent("taglist.plist")
     }
 

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -32,7 +32,8 @@ struct FilePath {
     }
 
     static var libraryUrl: URL? {
-        savingUrl?.appendingPathComponent(".Library")
+        savingUrl?.appendingPathComponent("Library")
+//        FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first?.appendingPathComponent("Tag")
     }
 
     static var fileName: String {
@@ -42,7 +43,7 @@ struct FilePath {
     }
 
     static var tagListFileUrl: URL? {
-        libraryUrl?.appendingPathComponent("taglist.plist")
+        libraryUrl?.appendingPathComponent("taglist.json")
     }
 
     static func makeDirectoryIfNeeded() {

--- a/PiecesOfPaper/Model/NoteEntity.swift
+++ b/PiecesOfPaper/Model/NoteEntity.swift
@@ -12,12 +12,12 @@ import PencilKit
 struct NoteEntity: Codable {
     var id = UUID()
     var drawing: PKDrawing
-    var tags: [String]
+    var tags: [TagEntity]
     var createdDate: Date
     var updatedDate: Date
 
     init(drawing: PKDrawing,
-         tags: [String] = [],
+         tags: [TagEntity] = [],
          createdDate: Date = Date(),
          updatedDate: Date = Date()) {
         self.drawing = drawing

--- a/PiecesOfPaper/Model/NotificationName.swift
+++ b/PiecesOfPaper/Model/NotificationName.swift
@@ -1,0 +1,14 @@
+//
+//  NotificationName.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2021/12/16.
+//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+
+public extension Notification.Name {
+    static let addedNewNote = Notification.Name("addedNewNote")
+    static let channgedTagToNote = Notification.Name("channgedTagToNote")
+}

--- a/PiecesOfPaper/Model/TagModel.swift
+++ b/PiecesOfPaper/Model/TagModel.swift
@@ -10,9 +10,9 @@ import Foundation
 
 struct TagModel {
     var tags: [TagEntity] {
-        guard let libraryUrl = FilePath.libraryUrl?.appendingPathComponent("taglist.plist"),
-                FileManager.default.fileExists(atPath: libraryUrl.path),
-              let content = FileManager.default.contents(atPath: libraryUrl.path) else { return [] }
+        guard let tagListFileUrl = FilePath.tagListFileUrl,
+                FileManager.default.fileExists(atPath: tagListFileUrl.path),
+              let content = FileManager.default.contents(atPath: tagListFileUrl.path) else { return [] }
         let decoder = PropertyListDecoder()
         do {
             return try decoder.decode([TagEntity].self, from: content)
@@ -30,8 +30,8 @@ struct TagModel {
     ]
 
     func fetch() -> [TagEntity] {
-        guard let tagListFileName = FilePath.tagListFileName else { return [] }
-        if !FileManager.default.fileExists(atPath: tagListFileName.path) {
+        guard let tagListFileUrl = FilePath.tagListFileUrl else { return [] }
+        if !FileManager.default.fileExists(atPath: tagListFileUrl.path) {
             makeFileIfNeeded()
             return defaultTags
         } else {

--- a/PiecesOfPaper/View/Canvas/Canvas.swift
+++ b/PiecesOfPaper/View/Canvas/Canvas.swift
@@ -87,7 +87,7 @@ struct Canvas: View {
                     }
                 }
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    if let document = viewModel.document {
+                    if viewModel.document != nil {
                         Button(action: {
                             toolPicker.setVisible(false, forFirstResponder: canvasView)
                             viewModel.showTagList.toggle()

--- a/PiecesOfPaper/View/Canvas/Canvas.swift
+++ b/PiecesOfPaper/View/Canvas/Canvas.swift
@@ -134,6 +134,7 @@ struct Canvas: View {
             return
         }
         viewModel.archive()
+        NotificationCenter.default.post(name: .addedNewNote, object: viewModel.document)
         presentationMode.wrappedValue.dismiss()
         reviewRequest()
     }
@@ -142,6 +143,7 @@ struct Canvas: View {
         if !UserPreference().enabledAutoSave {
             viewModel.save(drawing: canvasView.drawing)
         }
+        NotificationCenter.default.post(name: .addedNewNote, object: viewModel.document)
         presentationMode.wrappedValue.dismiss()
         reviewRequest()
     }

--- a/PiecesOfPaper/View/Canvas/NoteInformation.swift
+++ b/PiecesOfPaper/View/Canvas/NoteInformation.swift
@@ -72,7 +72,7 @@ struct NoteInformation: View {
                             Text("No tag")
                         } else {
                             ScrollView(.horizontal) {
-                                Text(document.entity.tags.reduce("") { $0 + $1 })
+                                TagHStack(tags: document.entity.tags)
                             }
                         }
                     }

--- a/PiecesOfPaper/View/NoteList/Notes.swift
+++ b/PiecesOfPaper/View/NoteList/Notes.swift
@@ -10,6 +10,13 @@ import SwiftUI
 
 struct Notes: View {
     @ObservedObject var viewModel: NotesViewModel
+    var actionButton: Alert.Button {
+        .destructive(
+            Text(viewModel.isTargetDirectoryArchived ?  "Unarchived" : "Archived"),
+            action: { viewModel.isTargetDirectoryArchived ? viewModel.allUnarchive() : viewModel.allArchive() }
+        )
+    }
+    var cancelButton: Alert.Button { .default(Text("Cancel")) }
 
     init(targetDirectory: NotesViewModel.TargetDirectory) {
         self.viewModel = NotesViewModel(targetDirectory: targetDirectory)
@@ -37,6 +44,9 @@ struct Notes: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button(action: { viewModel.toggleArchiveAlert() }) {
+                    Image(systemName: viewModel.isTargetDirectoryArchived ? "tray.circle" : "archivebox.circle")
+                }
                 Button(action: viewModel.toggleIsListConditionPopover ) { Image(systemName: "line.3.horizontal.decrease.circle") }
                 Button(action: viewModel.update) { Image(systemName: "arrow.triangle.2.circlepath") }
                     .disabled(!viewModel.isLoaded)
@@ -47,6 +57,13 @@ struct Notes: View {
             NavigationView {
                 ListConditionSetting(listCondition: $viewModel.listCondition)
             }
+        }
+        .alert(isPresented: $viewModel.showArchiveAlert) { () -> Alert in
+            Alert(title: Text("""
+                            Are you sure you want to \(viewModel.isTargetDirectoryArchived ? "unarchived" : "archived") \(viewModel.publishedNoteDocuments.count) notes ?
+                            """),
+                  primaryButton: actionButton,
+                  secondaryButton: cancelButton)
         }
     }
 

--- a/PiecesOfPaper/View/NoteList/Notes.swift
+++ b/PiecesOfPaper/View/NoteList/Notes.swift
@@ -39,6 +39,7 @@ struct Notes: View {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button(action: viewModel.toggleIsListConditionPopover ) { Image(systemName: "line.3.horizontal.decrease.circle") }
                 Button(action: viewModel.update) { Image(systemName: "arrow.triangle.2.circlepath") }
+                    .disabled(!viewModel.isLoaded)
                 Button(action: new) { Image(systemName: "plus.circle") }
             }
         }

--- a/PiecesOfPaper/View/NoteList/Notes.swift
+++ b/PiecesOfPaper/View/NoteList/Notes.swift
@@ -44,7 +44,7 @@ struct Notes: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button(action: { viewModel.toggleArchiveAlert() }) {
+                Button(action: { viewModel.toggleArchiveOrUnarchiveAlert() }) {
                     Image(systemName: viewModel.isTargetDirectoryArchived ? "tray.circle" : "archivebox.circle")
                 }
                 Button(action: viewModel.toggleIsListConditionPopover ) { Image(systemName: "line.3.horizontal.decrease.circle") }

--- a/PiecesOfPaper/View/Tag/TagListToNote.swift
+++ b/PiecesOfPaper/View/Tag/TagListToNote.swift
@@ -23,7 +23,7 @@ struct TagListToNote: View {
                         }
                         .contentShape(Rectangle())
                         .onTapGesture {
-                            viewModel.add(tagName: tag.name)
+                            viewModel.add(tagName: tag)
                         }
                     }
                 }

--- a/PiecesOfPaper/ViewModel/NotesViewModel.swift
+++ b/PiecesOfPaper/ViewModel/NotesViewModel.swift
@@ -43,7 +43,7 @@ final class NotesViewModel: ObservableObject {
     private var documentsAppliedConditions: [NoteDocument] {
         var notes = noteDocuments
         listCondition.filterBy.forEach { filteringTag in
-            notes = notes.filter { $0.entity.tags.contains(filteringTag.name) }
+            notes = notes.filter { $0.entity.tags.contains(filteringTag) }
         }
         switch listCondition.sortOrder {
         case .ascending:
@@ -167,7 +167,7 @@ final class NotesViewModel: ObservableObject {
         let tagModel = TagModel()
         let tags = tagModel.tags
         return tags.filter {
-            document.entity.tags.contains($0.name)
+            document.entity.tags.contains($0)
         }
     }
 

--- a/PiecesOfPaper/ViewModel/NotesViewModel.swift
+++ b/PiecesOfPaper/ViewModel/NotesViewModel.swift
@@ -13,6 +13,7 @@ final class NotesViewModel: ObservableObject {
     var objectWillChange = ObjectWillChangePublisher()
     var publishedNoteDocuments = [NoteDocument]()
     var isLoaded = false
+    var showArchiveAlert = false
     var isListConditionSheet = false {
         didSet {
             objectWillChange.send()
@@ -25,6 +26,10 @@ final class NotesViewModel: ObservableObject {
     }
 
     private var directory: TargetDirectory
+    var isTargetDirectoryArchived: Bool {
+        directory == .archived
+    }
+
     private var counter = 0
     private var noteDocuments = [NoteDocument]()
 
@@ -189,5 +194,18 @@ final class NotesViewModel: ObservableObject {
     func toggleIsListConditionPopover() {
         isListConditionSheet.toggle()
         objectWillChange.send()
+    }
+
+    func toggleArchiveAlert() {
+        showArchiveAlert.toggle()
+        objectWillChange.send()
+    }
+
+    func allArchive() {
+        noteDocuments.forEach { archive(document: $0) }
+    }
+
+    func allUnarchive() {
+        noteDocuments.forEach { unarchive(document: $0) }
     }
 }

--- a/PiecesOfPaper/ViewModel/TagListToNoteViewModel.swift
+++ b/PiecesOfPaper/ViewModel/TagListToNoteViewModel.swift
@@ -18,14 +18,14 @@ final class TagListToNoteViewModel: ObservableObject {
     var tagsToNote: [TagEntity] {
         guard let noteDocument = noteDocument else { return [] }
         return tags.filter {
-            noteDocument.entity.tags.contains($0.name)
+            noteDocument.entity.tags.contains($0)
         }
     }
 
     var tagsNotToNote: [TagEntity] {
         guard let noteDocument = noteDocument else { return [] }
         return tags.filter {
-            !noteDocument.entity.tags.contains($0.name)
+            !noteDocument.entity.tags.contains($0)
         }
     }
 
@@ -38,7 +38,7 @@ final class TagListToNoteViewModel: ObservableObject {
         }
     }
 
-    func add(tagName: String) {
+    func add(tagName: TagEntity) {
         guard let noteDocument = noteDocument else { return }
         noteDocument.entity.tags.append(tagName)
         save()
@@ -46,7 +46,7 @@ final class TagListToNoteViewModel: ObservableObject {
 
     func remove(tag: TagEntity) {
         guard let noteDocument = noteDocument else { return }
-        noteDocument.entity.tags = noteDocument.entity.tags.filter { $0 != tag.name }
+        noteDocument.entity.tags = noteDocument.entity.tags.filter { $0 != tag }
         save()
     }
 

--- a/PiecesOfPaper/ViewModel/TagListToNoteViewModel.swift
+++ b/PiecesOfPaper/ViewModel/TagListToNoteViewModel.swift
@@ -54,6 +54,7 @@ final class TagListToNoteViewModel: ObservableObject {
         guard let noteDocument = noteDocument else { return }
         noteDocument.save(to: noteDocument.fileURL, for: .forOverwriting) { [weak self] success in
             if success {
+                NotificationCenter.default.post(name: .channgedTagToNote, object: noteDocument)
                 self?.objectWillChange.send()
             } else {
                 print("save failed")


### PR DESCRIPTION
- `NoteEntity` tags type changed `[String]` -> `[TagEntity]`
- Now, user can handle their TagList file
- Changed notes fetch logic
- Added grid view refresh without access iCloud Drive
- Fixed the bug saving UserDefaults
- (Property observer wouldn't work for initializing)