### PR TITLE
Fix NavigationSplitView

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -85,7 +85,7 @@ disabled_rules:
 
 # デフォルト無効で有効にするルール
 opt_in_rules:
-  - anyobject_protocol
+# - anyobject_protocol
   - array_init
 #  - attributes
 # - closure_body_length # SwiftUIだと守れないため
@@ -189,6 +189,6 @@ line_length:
   warning: 300
   error: 500
 
-#identifier_name:
+identifier_name:
   min_length:
     warning: 1 # `r` `g` `b` などを使いたいため

--- a/PiecesOfPaper/Model/Notification+.swift
+++ b/PiecesOfPaper/Model/Notification+.swift
@@ -1,5 +1,6 @@
+// swiftlint:disable:this file_name
 //
-//  Notification++.swift
+//  Notification+.swift
 //  PiecesOfPaper
 //
 //  Created by Nakajima on 2025/01/19.

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -12,36 +12,67 @@ struct SideBarListView: View {
     @StateObject private var inboxNoteViewModel = NoteViewModel(targetDirectory: .inbox)
     @StateObject private var allNoteViewModel = NoteViewModel(targetDirectory: .all)
     @StateObject private var archivedNoteViewModel = NoteViewModel(targetDirectory: .archived)
+    @State private var selection: Page? = .inbox
+    private enum Page: String, CaseIterable {
+        case inbox, all, trash
+        case tag
+        case setting
+        
+        var label: String {
+            switch self {
+            case .inbox: "Inbox"
+            case .all: "All"
+            case .trash: "Trash"
+            case .tag: "Tag List"
+            case .setting: "Setting"
+            }
+        }
+    }
 
     var body: some View {
         NavigationSplitView {
             sideBarList
         } detail: {
-            NoteListParentView(viewModel: inboxNoteViewModel)
+            switch selection {
+            case .inbox:
+                NoteListParentView(viewModel: inboxNoteViewModel)
+            case .all:
+                NoteListParentView(viewModel: allNoteViewModel)
+            case .trash:
+                NoteListParentView(viewModel: archivedNoteViewModel)
+            case .tag:
+                TagList()
+            case .setting:
+                SettingView()
+            default:
+                Text("Unknown page")
+            }
         }
     }
 
     private var sideBarList: some View {
-        List {
-            Section(header: Text("Folder")) {
-                NavigationLink(destination: NoteListParentView(viewModel: inboxNoteViewModel)) {
-                    Label("Inbox", systemImage: "tray")
+        List(selection: $selection) {
+            Section(header: Text("Folders")) {
+                NavigationLink(value: Page.inbox) {
+                    Label(Page.inbox.label, systemImage: "tray")
                 }
-                NavigationLink(destination: NoteListParentView(viewModel: allNoteViewModel)) {
-                    Label("All", systemImage: "tray.full")
+
+                NavigationLink(value: Page.all) {
+                    Label(Page.all.label, systemImage: "tray.full")
                 }
-                NavigationLink(destination: NoteListParentView(viewModel: archivedNoteViewModel)) {
-                    Label("Trash", systemImage: "trash")
+
+                NavigationLink(value: Page.trash) {
+                    Label(Page.trash.label, systemImage: "trash")
                 }
             }
             Section(header: Text("Tag")) {
-                NavigationLink(destination: TagList()) {
-                    Label("Tag List", systemImage: "tag")
+                NavigationLink(value: Page.tag) {
+                    Label(Page.tag.label, systemImage: "tag")
                 }
             }
             Section(header: Text("Setting")) {
-                NavigationLink(destination: SettingView()) {
-                    Label("Setting", systemImage: "gearshape")
+                NavigationLink(value: Page.setting) {
+                    Label(Page.setting.label, systemImage: "gearshape")
                 }
             }
         }

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -18,7 +18,7 @@ struct NoteListParentView: View {
 
     var body: some View {
         Group {
-            if viewModel.isLoading {
+            if viewModel.isShowLoading {
                 ProgressView()
             } else {
                 if viewModel.displayNoteDocuments.isEmpty {
@@ -93,7 +93,7 @@ struct NoteListParentView: View {
             } label: {
                 Image(systemName: "arrow.triangle.2.circlepath")
             }
-            .disabled(viewModel.isLoading)
+            .disabled(viewModel.isShowLoading)
             Button {
                 openNewNote()
             } label: {

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -32,6 +32,11 @@ struct NoteListParentView: View {
         .task {
             await viewModel.incrementalFetch()
         }
+        .refreshable {
+            Task {
+                await viewModel.reload()
+            }
+        }
         .toolbar {
             toolbarItems
         }

--- a/PiecesOfPaper/ViewModel/NoteViewModel.swift
+++ b/PiecesOfPaper/ViewModel/NoteViewModel.swift
@@ -11,8 +11,7 @@ import Foundation
 @MainActor
 final class NoteViewModel: ObservableObject {
     @Published var displayNoteDocuments = [NoteDocument]()
-    // Set initial value to true to show loading state when view appears
-    @Published var isLoading = true
+    @Published var isShowLoading = true
     private var noteDocuments = [NoteDocument]()
     enum TargetDirectory: String {
         case inbox, archived, all
@@ -45,9 +44,9 @@ final class NoteViewModel: ObservableObject {
 
     func incrementalFetch() async {
         defer {
-            isLoading = false
+            isShowLoading = false
         }
-        isLoading = true
+        isShowLoading = true
         let (added, removed) = fetchChangedFileUrls()
         // FIXME: - デバッグ終わったら消す
         print("added: \(added.count), removed: \(removed.count)")

--- a/swiftlint.result
+++ b/swiftlint.result
@@ -1,7 +1,0 @@
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:28:1 Corrected Trailing Whitespace
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:72:1 Corrected Trailing Whitespace
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:81:1 Corrected Trailing Whitespace
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:151:1 Corrected Trailing Whitespace
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:153:1 Corrected Trailing Whitespace
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/CanvasViewModel.swift:28:37: warning: Force Unwrapping Violation: Force unwrapping should be avoided (force_unwrapping)
-/Users/nakajima/Dev/PiecesOfPaper/PiecesOfPaper/ViewModel/NotesViewModel.swift:118:20: warning: Todo Violation: FIXMEs should be resolved (- need notification to user) (todo)


### PR DESCRIPTION
close #132 

- The incorrect handling of NavigationSplitView was causing the `.task` not to be called