### PR TITLE
Fix version bumping script to work with modern Xcode projects

### DIFF
--- a/PiecesOfPaperTests/Info.plist
+++ b/PiecesOfPaperTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Fix bump-version.sh to correctly read and update version numbers in modern Xcode projects
- Update test target to use build setting variables for consistency

## Background
The `agvtool what-marketing-version` command couldn't read version numbers because the Info.plist files use `$(MARKETING_VERSION)` variable references (modern Xcode practice). The actual version value is stored in project.pbxproj as a build setting, which agvtool cannot read.

## Changes
- Use `xcodebuild -showBuildSettings` to read MARKETING_VERSION and CURRENT_PROJECT_VERSION from build settings
- Use direct project.pbxproj editing to update version settings (preserving Info.plist variable references)
- Update PiecesOfPaperTests/Info.plist to use build setting variables instead of hardcoded values
- Add version format validation (X.Y.Z)

## Test Results
All version management operations work correctly:
- ✅ Reading current version/build numbers
- ✅ Setting specific versions
- ✅ Bumping patch/minor/major versions
- ✅ Incrementing build numbers
- ✅ Info.plist variable references preserved
- ✅ App builds successfully with correct version info

🤖 Generated with [Claude Code](https://claude.com/claude-code)