### PR TITLE
Fix Picker reset issue with callback pattern

### DIFF
--- a/PiecesOfPaper/View/NoteList/ListOrderSettingView.swift
+++ b/PiecesOfPaper/View/NoteList/ListOrderSettingView.swift
@@ -10,10 +10,12 @@ import SwiftUI
 
 struct ListOrderSettingView: View {
     @State private var viewModel: ListOrderSettingViewModel
+    @Binding private var parentListOrder: ListOrder
     @Environment(\.dismiss) private var dismiss
 
     init(listOrder: Binding<ListOrder>) {
-        self._viewModel = State(initialValue: ListOrderSettingViewModel(listOrder: listOrder))
+        self._parentListOrder = listOrder
+        self._viewModel = State(initialValue: ListOrderSettingViewModel(listOrder: listOrder.wrappedValue))
     }
 
     var body: some View {
@@ -32,6 +34,9 @@ struct ListOrderSettingView: View {
             }
             .pickerStyle(.segmented)
             .padding()
+            .onChange(of: viewModel.listOrder.sortBy) { _, newValue in
+                viewModel.updateSortBy(newValue)
+            }
             HStack {
                 Image(systemName: "arrow.up.arrow.down.circle")
                 Text("Sort Order")
@@ -46,6 +51,9 @@ struct ListOrderSettingView: View {
             }
             .pickerStyle(.segmented)
             .padding()
+            .onChange(of: viewModel.listOrder.sortOrder) { _, newValue in
+                viewModel.updateSortOrder(newValue)
+            }
             HStack {
                 Image(systemName: "line.3.horizontal.decrease.circle")
                 Text("Filter by")
@@ -68,6 +76,11 @@ struct ListOrderSettingView: View {
             .padding()
             Spacer()
 
+        }
+        .onAppear {
+            viewModel.onListOrderChanged = { [self] newListOrder in
+                self.parentListOrder = newListOrder
+            }
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {

--- a/PiecesOfPaper/ViewModel/ListOrderSettingViewModel.swift
+++ b/PiecesOfPaper/ViewModel/ListOrderSettingViewModel.swift
@@ -11,18 +11,22 @@ import SwiftUI
 
 @Observable
 final class ListOrderSettingViewModel {
-    @ObservationIgnored @Binding var listOrder: ListOrder
+    var listOrder: ListOrder
     private var tags: [TagEntity]
     var filteringTag: [TagEntity]
     var nonFilteringTag: [TagEntity]
 
-    init(listOrder: Binding<ListOrder>) {
-        self._listOrder = listOrder
+    // Callback to notify parent of changes
+    var onListOrderChanged: ((ListOrder) -> Void)?
+
+    init(listOrder: ListOrder) {
+        self.listOrder = listOrder
         let allTags = TagModel().tags
         self.tags = allTags
-        self.filteringTag = allTags.filter { listOrder.wrappedValue.filterBy.contains($0) }
-        self.nonFilteringTag = allTags.filter { !listOrder.wrappedValue.filterBy.contains($0) }
+        self.filteringTag = allTags.filter { listOrder.filterBy.contains($0) }
+        self.nonFilteringTag = allTags.filter { !listOrder.filterBy.contains($0) }
     }
+
     private func updatedFilterTag() {
         filteringTag = tags.filter { listOrder.filterBy.contains($0) }
         nonFilteringTag = tags.filter { !listOrder.filterBy.contains($0) }
@@ -31,10 +35,26 @@ final class ListOrderSettingViewModel {
     func add(tag: TagEntity) {
         listOrder.filterBy.append(tag)
         updatedFilterTag()
+        notifyChange()
     }
 
     func remove(tag: TagEntity) {
         listOrder.filterBy = listOrder.filterBy.filter { $0 != tag }
         updatedFilterTag()
+        notifyChange()
+    }
+
+    func updateSortBy(_ newValue: ListOrder.SortBy) {
+        listOrder.sortBy = newValue
+        notifyChange()
+    }
+
+    func updateSortOrder(_ newValue: ListOrder.SortOrder) {
+        listOrder.sortOrder = newValue
+        notifyChange()
+    }
+
+    private func notifyChange() {
+        onListOrderChanged?(listOrder)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #158 by implementing a callback pattern to eliminate the Picker reset bug in `ListOrderSettingView`.

## Problem

When users changed Picker values in the sort settings screen:
1. Picker would visually reset to initial value
2. Picker would become unresponsive
3. Settings wouldn't persist properly

**Root Cause**: Conflict between `@State` and `@Binding` in ViewModel architecture caused SwiftUI to lose track of the source of truth.

## Solution

Implemented callback pattern with the following changes:

### ListOrderSettingViewModel
- ✅ Removed `@ObservationIgnored @Binding var listOrder`
- ✅ Changed to `var listOrder: ListOrder` (local copy)
- ✅ Added `var onListOrderChanged: ((ListOrder) -> Void)?` callback
- ✅ Removed `@ObservationIgnored` to enable proper `@Observable` behavior
- ✅ Added explicit methods: `updateSortBy(_:)` and `updateSortOrder(_:)`
- ✅ Added `notifyChange()` to all mutation methods (including `add(tag:)` and `remove(tag:)`)

### ListOrderSettingView
- ✅ Added `@Binding private var parentListOrder` to hold parent's binding
- ✅ Pass `listOrder.wrappedValue` (value, not binding) to ViewModel
- ✅ Updated `onChange` handlers to use specific update methods
- ✅ Added `.onAppear` to set up callback that updates parent

## Data Flow

```
User changes Picker
    ↓
$viewModel.listOrder.sortBy updates (local @State)
    ↓
onChange fires → viewModel.updateSortBy(newValue)
    ↓
ViewModel updates local listOrder → notifyChange()
    ↓
Callback invokes → parentListOrder = newListOrder
    ↓
Parent's NoteViewModel.listOrder didSet fires
    ↓
Settings saved to UserDefaults
```

## Benefits

- **Fixes Picker reset**: Local `@State` prevents binding conflicts
- **Ensures persistence**: Callback explicitly updates parent binding → didSet fires
- **Removes workaround**: No more `@ObservationIgnored` or struct recreation
- **Clear data flow**: Explicit callback makes persistence obvious
- **Better maintainability**: No hidden side effects

## Testing

Tested manually:
- [x] Picker maintains selected value (no reset)
- [x] Picker remains interactive after changes
- [x] Settings persist after app restart
- [x] Filter tags work correctly
- [x] Sort changes reflect immediately in note list

## Future Work

Created issues for broader architectural improvements:
- #159: Refactor ViewModel layer to eliminate didSet pattern
- #160: Separate NoteDocument responsibilities
- #161: Centralize persistence layer
- #162: Meta issue for UIDocument/SwiftUI architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)