### PR TITLE
Fix scroll-to-bottom functionality

### DIFF
--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -180,7 +180,11 @@ struct NoteListParentView: View {
         }
 
         func scrollToBottom(proxy: ScrollViewProxy) {
-            proxy.scrollTo(viewModel.displayNoteDocuments.endIndex - 1, anchor: .bottom)
+            guard let lastDocument =
+        viewModel.displayNoteDocuments.last else { return }
+            withAnimation {
+                proxy.scrollTo(lastDocument.id, anchor: .bottom)
+            }
         }
     }
 

--- a/PiecesOfPaper/View/NoteList/NoteListView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListView.swift
@@ -28,6 +28,7 @@ struct NoteListView: View {
                     )
                         .padding(.horizontal)
                 }
+                .id(document.id)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixed scrollToBottom method to use document UUID instead of array index
- Added explicit .id() modifier for improved scroll target clarity
- Added smooth animation and safe handling for empty arrays

Fixes #166

## Problem
The scroll-to-bottom button was not working because the `scrollToBottom` method was passing an array index to `ScrollViewProxy.scrollTo()`, which expects a view identifier (UUID). This became more apparent after recent list ordering changes.

## Solution
- Changed from `proxy.scrollTo(endIndex - 1)` to `proxy.scrollTo(lastDocument.id)`
- Added guard clause for safe handling of empty document lists
- Wrapped scroll action in `withAnimation` for smooth scrolling
- Added explicit `.id(document.id)` modifier to ForEach items in NoteListView

## Files Changed
- `PiecesOfPaper/View/NoteList/NoteListParentView.swift` - Fixed scrollToBottom method
- `PiecesOfPaper/View/NoteList/NoteListView.swift` - Added explicit .id() modifier

## Testing
- Scroll-to-bottom button now works correctly
- Works reliably regardless of sort order
- Handles edge cases (empty list, single item, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)