### PR TITLE
Fix silent data-loss paths in note persistence

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		A70000000000000000000015 /* TagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000005 /* TagStore.swift */; };
 		A70000000000000000000016 /* PreferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000006 /* PreferenceStore.swift */; };
 		A70000000000000000000017 /* NoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000007 /* NoteStoreTests.swift */; };
+		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,6 +102,7 @@
 		A70000000000000000000005 /* TagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStore.swift; sourceTree = "<group>"; };
 		A70000000000000000000006 /* PreferenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStore.swift; sourceTree = "<group>"; };
 		A70000000000000000000007 /* NoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStoreTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				A70000000000000000000007 /* NoteStoreTests.swift */,
+				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A6A16EC625B1673500DF323F /* Info.plist */,
 			);
 			path = PiecesOfPaperTests;
@@ -397,6 +400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
+				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -33,19 +33,14 @@ final class NoteDocument: UIDocument, Identifiable {
     }
 
     override func contents(forType typeName: String) throws -> Any {
-        let encoder = PropertyListEncoder()
-        let data = (try? encoder.encode(entity)) ?? Data()
-        return data
+        try PropertyListEncoder().encode(entity)
     }
 
     override func load(fromContents contents: Any, ofType typeName: String?) throws {
-        guard let content = contents as? Data else { return }
-        let decoder = PropertyListDecoder()
-        do {
-            entity = try decoder.decode(NoteEntity.self, from: content)
-        } catch {
-            print("Data file format error: ", error.localizedDescription)
+        guard let content = contents as? Data else {
+            throw NoteDocumentError.invalidContents
         }
+        entity = try PropertyListDecoder().decode(NoteEntity.self, from: content)
     }
 
     // The later is the winner
@@ -65,5 +60,13 @@ final class NoteDocument: UIDocument, Identifiable {
         }
 
         return NoteDocument(fileURL: url, entity: NoteEntity(drawing: PKDrawing()))
+    }
+}
+
+enum NoteDocumentError: LocalizedError {
+    case invalidContents
+
+    var errorDescription: String? {
+        "The note file is not in a readable format."
     }
 }

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -12,6 +12,7 @@ import PencilKit
 final class NoteDocument: UIDocument, Identifiable {
     var entity: NoteEntity
     var id: UUID { entity.id }
+    private var stateObserver: NSObjectProtocol?
 
     var isArchived: Bool {
         guard let archivedUrl = FilePath.archivedUrl else { return false }
@@ -21,15 +22,31 @@ final class NoteDocument: UIDocument, Identifiable {
     override init(fileURL: URL) {
         self.entity = NoteEntity(drawing: PKDrawing())
         super.init(fileURL: fileURL)
-
-        if self.documentState == .inConflict {
-            resolveConflict(url: fileURL)
-        }
+        observeStateChange()
     }
 
     init(fileURL: URL, entity: NoteEntity) {
         self.entity = entity
         super.init(fileURL: fileURL)
+        observeStateChange()
+    }
+
+    deinit {
+        if let stateObserver {
+            NotificationCenter.default.removeObserver(stateObserver)
+        }
+    }
+
+    // Conflict state is populated asynchronously after open(), never at init time,
+    // so it has to be watched through stateChangedNotification.
+    private func observeStateChange() {
+        stateObserver = NotificationCenter.default.addObserver(
+            forName: UIDocument.stateChangedNotification,
+            object: self,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resolveConflictIfNeeded()
+        }
     }
 
     override func contents(forType typeName: String) throws -> Any {
@@ -44,14 +61,14 @@ final class NoteDocument: UIDocument, Identifiable {
     }
 
     // The later is the winner
-    private func resolveConflict(url: URL) {
-        let currentVersion = NSFileVersion.currentVersionOfItem(at: url)
+    private func resolveConflictIfNeeded() {
+        guard documentState.contains(.inConflict) else { return }
         do {
-            try NSFileVersion.removeOtherVersionsOfItem(at: url)
+            try NSFileVersion.removeOtherVersionsOfItem(at: fileURL)
+            NSFileVersion.currentVersionOfItem(at: fileURL)?.isResolved = true
         } catch {
-            print("failed delete conflict files")
+            print("failed to delete conflict versions: ", error.localizedDescription)
         }
-        currentVersion?.isResolved = true
     }
 
     static func createTestData() -> NoteDocument {

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -22,11 +22,11 @@ enum NoteDirectory: String {
 protocol NoteRepositoryProtocol: AnyObject {
     func getFileUrls(directory: NoteDirectory) -> [URL]
     @MainActor func open(fileUrl: URL) async throws -> NoteDocument
-    func save(document: NoteDocument)
-    func save(document: NoteDocument, for saveOperation: UIDocument.SaveOperation)
+    func save(document: NoteDocument, completion: @escaping (Bool) -> Void)
     func delete(fileUrl: URL) throws
     func move(fileUrl: URL, to directory: NoteDirectory) throws -> URL
-    func duplicate(document: NoteDocument, in directory: NoteDirectory) -> NoteDocument?
+    func duplicate(document: NoteDocument, in directory: NoteDirectory,
+                   completion: @escaping (NoteDocument?) -> Void)
 }
 
 final class NoteRepository: NoteRepositoryProtocol {
@@ -52,16 +52,10 @@ final class NoteRepository: NoteRepositoryProtocol {
         }
     }
 
-    func save(document: NoteDocument) {
-        if FileManager.default.fileExists(atPath: document.fileURL.path) {
-            document.save(to: document.fileURL, for: .forOverwriting)
-        } else {
-            document.save(to: document.fileURL, for: .forCreating)
-        }
-    }
-
-    func save(document: NoteDocument, for saveOperation: UIDocument.SaveOperation) {
-        document.save(to: document.fileURL, for: saveOperation)
+    func save(document: NoteDocument, completion: @escaping (Bool) -> Void) {
+        let saveOperation: UIDocument.SaveOperation =
+            FileManager.default.fileExists(atPath: document.fileURL.path) ? .forOverwriting : .forCreating
+        document.save(to: document.fileURL, for: saveOperation, completionHandler: completion)
     }
 
     func delete(fileUrl: URL) throws {
@@ -77,13 +71,18 @@ final class NoteRepository: NoteRepositoryProtocol {
         return toUrl
     }
 
-    func duplicate(document: NoteDocument, in directory: NoteDirectory) -> NoteDocument? {
-        guard let directoryUrl = directory.url else { return nil }
+    func duplicate(document: NoteDocument, in directory: NoteDirectory,
+                   completion: @escaping (NoteDocument?) -> Void) {
+        guard let directoryUrl = directory.url else {
+            completion(nil)
+            return
+        }
         let newUrl = directoryUrl.appendingPathComponent(FilePath.fileName)
         let entity = NoteEntity(drawing: document.entity.drawing)
         let newDocument = NoteDocument(fileURL: newUrl, entity: entity)
-        newDocument.save(to: newUrl, for: .forCreating)
-        return newDocument
+        newDocument.save(to: newUrl, for: .forCreating) { success in
+            completion(success ? newDocument : nil)
+        }
     }
 }
 

--- a/PiecesOfPaper/Repository/TagRepository.swift
+++ b/PiecesOfPaper/Repository/TagRepository.swift
@@ -10,7 +10,8 @@ import Foundation
 
 protocol TagRepositoryProtocol {
     func fetchAll() -> [TagEntity]
-    func saveAll(_ tags: [TagEntity])
+    @discardableResult
+    func saveAll(_ tags: [TagEntity]) -> Bool
 }
 
 struct TagRepository: TagRepositoryProtocol {
@@ -33,16 +34,18 @@ struct TagRepository: TagRepositoryProtocol {
         }
     }
 
-    func saveAll(_ tags: [TagEntity]) {
-        guard let tagListFileUrl = FilePath.tagListFileUrl else { return }
+    @discardableResult
+    func saveAll(_ tags: [TagEntity]) -> Bool {
+        guard let tagListFileUrl = FilePath.tagListFileUrl else { return false }
         syncFile(url: tagListFileUrl)
 
-        let encoder = JSONEncoder()
-        guard let data = try? encoder.encode(tags) else { return }
         do {
+            let data = try JSONEncoder().encode(tags)
             try data.write(to: tagListFileUrl)
+            return true
         } catch {
             print(error.localizedDescription)
+            return false
         }
     }
 

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -124,37 +124,47 @@ final class NoteStore {
     }
 
     private func updateDocuments(addedUrls: [URL], removedUrls: [URL], directory: NoteDirectory) async {
-        do {
-            let newDocuments = try await withThrowingTaskGroup(of: NoteDocument.self) { [weak self] group in
-                guard let self = self else { return [NoteDocument]() }
-                var documents: [NoteDocument] = []
-                for url in addedUrls {
-                    group.addTask {
-                        try await self.noteRepository.open(fileUrl: url)
-                    }
+        let (newDocuments, failedUrls) = await withTaskGroup(
+            of: (url: URL, document: NoteDocument?).self
+        ) { group -> ([NoteDocument], [URL]) in
+            for url in addedUrls {
+                group.addTask {
+                    (url, try? await self.noteRepository.open(fileUrl: url))
                 }
+            }
 
-                for try await document in group {
+            var documents: [NoteDocument] = []
+            var failed: [URL] = []
+            for await result in group {
+                if let document = result.document {
                     documents.append(document)
-                }
-
-                return documents
-            }
-
-            switch directory {
-            case .inbox:
-                inboxDocuments += newDocuments
-                removedUrls.forEach { url in
-                    inboxDocuments.removeAll { $0.fileURL == url }
-                }
-            case .archived:
-                archivedDocuments += newDocuments
-                removedUrls.forEach { url in
-                    archivedDocuments.removeAll { $0.fileURL == url }
+                } else {
+                    failed.append(result.url)
                 }
             }
-        } catch {
-            // FIXME: - need alert
+
+            return (documents, failed)
+        }
+
+        switch directory {
+        case .inbox:
+            inboxDocuments += newDocuments
+            // Drop failed URLs from the cache so the next fetch retries them
+            inboxCachedUrls.removeAll { failedUrls.contains($0) }
+            removedUrls.forEach { url in
+                inboxDocuments.removeAll { $0.fileURL == url }
+            }
+        case .archived:
+            archivedDocuments += newDocuments
+            archivedCachedUrls.removeAll { failedUrls.contains($0) }
+            removedUrls.forEach { url in
+                archivedDocuments.removeAll { $0.fileURL == url }
+            }
+        }
+
+        if !failedUrls.isEmpty {
+            alertType = .error(NoteStoreError.openFailed(count: failedUrls.count))
+            showAlert = true
         }
     }
 
@@ -277,5 +287,19 @@ final class NoteStore {
         archivedCachedUrls.removeAll { $0 == document.fileURL }
         inboxDocuments.removeAll { $0.entity.id == document.entity.id }
         archivedDocuments.removeAll { $0.entity.id == document.entity.id }
+    }
+}
+
+enum NoteStoreError: LocalizedError {
+    case openFailed(count: Int)
+    case saveFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .openFailed(let count):
+            "Failed to load \(count) note(s). The files may be corrupted or not downloaded yet."
+        case .saveFailed:
+            "Failed to save the note."
+        }
     }
 }

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -197,14 +197,21 @@ final class NoteStore {
     // MARK: - Data operations
 
     func duplicate(_ document: NoteDocument, in directory: NoteDirectory) {
-        guard let newDocument = noteRepository.duplicate(document: document, in: directory) else { return }
-        switch directory {
-        case .inbox:
-            inboxCachedUrls.append(newDocument.fileURL)
-            inboxDocuments.append(newDocument)
-        case .archived:
-            archivedCachedUrls.append(newDocument.fileURL)
-            archivedDocuments.append(newDocument)
+        noteRepository.duplicate(document: document, in: directory) { [weak self] newDocument in
+            guard let self else { return }
+            guard let newDocument else {
+                self.alertType = .error(NoteStoreError.saveFailed)
+                self.showAlert = true
+                return
+            }
+            switch directory {
+            case .inbox:
+                self.inboxCachedUrls.append(newDocument.fileURL)
+                self.inboxDocuments.append(newDocument)
+            case .archived:
+                self.archivedCachedUrls.append(newDocument.fileURL)
+                self.archivedDocuments.append(newDocument)
+            }
         }
     }
 
@@ -261,14 +268,30 @@ final class NoteStore {
 
     func addTag(_ tag: TagEntity, to document: NoteDocument) {
         document.entity.tags.append(tag)
-        noteRepository.save(document: document)
-        updateDocumentInArray(document)
+        noteRepository.save(document: document) { [weak self] success in
+            guard let self else { return }
+            if success {
+                self.updateDocumentInArray(document)
+            } else {
+                document.entity.tags.removeAll { $0 == tag }
+                self.alertType = .error(NoteStoreError.saveFailed)
+                self.showAlert = true
+            }
+        }
     }
 
     func removeTag(_ tag: TagEntity, from document: NoteDocument) {
         document.entity.tags.removeAll { $0 == tag }
-        noteRepository.save(document: document)
-        updateDocumentInArray(document)
+        noteRepository.save(document: document) { [weak self] success in
+            guard let self else { return }
+            if success {
+                self.updateDocumentInArray(document)
+            } else {
+                document.entity.tags.append(tag)
+                self.alertType = .error(NoteStoreError.saveFailed)
+                self.showAlert = true
+            }
+        }
     }
 
     // MARK: - Private helpers

--- a/PiecesOfPaper/Store/TagStore.swift
+++ b/PiecesOfPaper/Store/TagStore.swift
@@ -21,17 +21,24 @@ final class TagStore {
 
     func add(_ tag: TagEntity) {
         tags.append(tag)
-        repository.saveAll(tags)
+        saveOrRollback()
     }
 
     func remove(at offsets: IndexSet) {
         tags.remove(atOffsets: offsets)
-        repository.saveAll(tags)
+        saveOrRollback()
     }
 
     func remove(_ tag: TagEntity) {
         tags.removeAll { $0 == tag }
-        repository.saveAll(tags)
+        saveOrRollback()
+    }
+
+    // Reload from disk when a save fails so the UI never shows a state that was not persisted
+    private func saveOrRollback() {
+        if !repository.saveAll(tags) {
+            reload()
+        }
     }
 
     func tagsFor(document: NoteDocument) -> [TagEntity] {

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -58,8 +58,11 @@ struct CanvasView: View {
         .alert("", isPresented: $showUnsavedAlert) {
             Button {
                 canvasViewModel.document.entity.drawing = canvasView.drawing
-                canvasViewModel.save()
-                closeCanvas()
+                canvasViewModel.save { success in
+                    if success {
+                        closeCanvas()
+                    }
+                }
             } label: {
                 Text("Save")
             }
@@ -70,6 +73,12 @@ struct CanvasView: View {
             }
          } message: {
              Text("Save changes?")
+        }
+        .alert("Failed to save the note",
+               isPresented: $canvasViewModel.showSaveFailedAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Your latest changes may not be persisted.")
         }
     }
 

--- a/PiecesOfPaper/ViewModel/CanvasViewModel.swift
+++ b/PiecesOfPaper/ViewModel/CanvasViewModel.swift
@@ -13,6 +13,7 @@ import PencilKit
 final class CanvasViewModel {
     private(set) var document: NoteDocument
     var showDrawingInformation = false
+    var showSaveFailedAlert = false
     private let noteRepository: NoteRepositoryProtocol
 
     var canReviewRequest: Bool {
@@ -33,15 +34,19 @@ final class CanvasViewModel {
         self.noteRepository = noteRepository
     }
 
-    func save() {
+    func save(completion: ((Bool) -> Void)? = nil) {
         document.entity.updatedDate = Date()
-        noteRepository.save(document: document)
+        noteRepository.save(document: document) { [weak self] success in
+            if !success {
+                self?.showSaveFailedAlert = true
+            }
+            completion?(success)
+        }
     }
 
     func save(drawing: PKDrawing) {
         guard document.entity.drawing != drawing else { return }
         document.entity.drawing = drawing
-        document.entity.updatedDate = Date()
-        noteRepository.save(document: document)
+        save()
     }
 }

--- a/PiecesOfPaperTests/NoteDocumentTests.swift
+++ b/PiecesOfPaperTests/NoteDocumentTests.swift
@@ -1,0 +1,45 @@
+//
+//  NoteDocumentTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/11.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Pieces_of_Paper
+
+@MainActor
+struct NoteDocumentTests {
+    @Test func contents_encodesEntity() throws {
+        let document = NoteDocument.createTestData()
+        let data = try #require(try document.contents(forType: "") as? Data)
+        let decoded = try PropertyListDecoder().decode(NoteEntity.self, from: data)
+        #expect(decoded.id == document.entity.id)
+    }
+
+    @Test func load_roundTripsEntity() throws {
+        let document = NoteDocument.createTestData()
+        let data = try #require(try document.contents(forType: "") as? Data)
+        let other = NoteDocument.createTestData()
+        try other.load(fromContents: data, ofType: nil)
+        #expect(other.entity.id == document.entity.id)
+    }
+
+    @Test func load_throwsOnGarbageData() {
+        let document = NoteDocument.createTestData()
+        let originalId = document.entity.id
+        #expect(throws: (any Error).self) {
+            try document.load(fromContents: Data("not a plist".utf8), ofType: nil)
+        }
+        #expect(document.entity.id == originalId)
+    }
+
+    @Test func load_throwsOnNonDataContents() {
+        let document = NoteDocument.createTestData()
+        #expect(throws: NoteDocumentError.self) {
+            try document.load(fromContents: NSObject(), ofType: nil)
+        }
+    }
+}

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -54,6 +54,25 @@ struct NoteStoreTests {
         #expect(noteStore.displayInboxDocuments.count == 3)
         #expect(noteStore.displayArchivedDocuments.isEmpty)
     }
+
+    @Test func test_addTag_persistsTagOnSuccessfulSave() async {
+        await noteStore.incrementalFetch(directory: .inbox)
+        let target = noteStore.displayInboxDocuments[0]
+        let tag = TagEntity(name: "test", color: CodableUIColor(uiColor: .red))
+        noteStore.addTag(tag, to: target)
+        #expect(target.entity.tags == [tag])
+        #expect(!noteStore.showAlert)
+    }
+
+    @Test func test_addTag_rollsBackTagWhenSaveFails() async {
+        await noteStore.incrementalFetch(directory: .inbox)
+        repositoryMock.saveShouldSucceed = false
+        let target = noteStore.displayInboxDocuments[0]
+        let tag = TagEntity(name: "test", color: CodableUIColor(uiColor: .red))
+        noteStore.addTag(tag, to: target)
+        #expect(target.entity.tags.isEmpty)
+        #expect(noteStore.showAlert)
+    }
 }
 
 final class NoteRepositoryMock: NoteRepositoryProtocol {
@@ -103,9 +122,10 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         }
     }
 
-    func save(document: NoteDocument) {}
-
-    func save(document: NoteDocument, for saveOperation: UIDocument.SaveOperation) {}
+    var saveShouldSucceed = true
+    func save(document: NoteDocument, completion: @escaping (Bool) -> Void) {
+        completion(saveShouldSucceed)
+    }
 
     func delete(fileUrl: URL) throws {}
 
@@ -116,8 +136,9 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         return fileUrl
     }
 
-    func duplicate(document: NoteDocument, in directory: NoteDirectory) -> NoteDocument? {
-        nil
+    func duplicate(document: NoteDocument, in directory: NoteDirectory,
+                   completion: @escaping (NoteDocument?) -> Void) {
+        completion(nil)
     }
 }
 

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -13,11 +13,13 @@ import Testing
 @MainActor
 struct NoteStoreTests {
     var noteStore: NoteStore
+    let repositoryMock: NoteRepositoryMock
     let documents = (0...2).map { _ in NoteDocument.createTestData() }
 
     init() {
+        repositoryMock = NoteRepositoryMock(documents: documents)
         noteStore = NoteStore(
-            noteRepository: NoteRepositoryMock(documents: documents),
+            noteRepository: repositoryMock,
             preferenceRepository: PreferenceRepositoryMock()
         )
     }
@@ -25,6 +27,32 @@ struct NoteStoreTests {
     @Test func test_incrementalFetch() async throws {
         await noteStore.incrementalFetch(directory: .inbox)
         #expect(noteStore.displayInboxDocuments == documents.reversed())
+    }
+
+    @Test func test_incrementalFetch_skipsUnreadableFileAndShowsError() async {
+        repositoryMock.failingUrls = [NoteRepositoryMock.TestFile.file2.url]
+        await noteStore.incrementalFetch(directory: .inbox)
+        #expect(noteStore.displayInboxDocuments.count == 2)
+        #expect(noteStore.showAlert)
+    }
+
+    @Test func test_incrementalFetch_retriesFailedFileOnNextFetch() async {
+        repositoryMock.failingUrls = [NoteRepositoryMock.TestFile.file2.url]
+        await noteStore.incrementalFetch(directory: .inbox)
+        #expect(noteStore.displayInboxDocuments.count == 2)
+
+        repositoryMock.failingUrls = []
+        await noteStore.incrementalFetch(directory: .inbox)
+        #expect(noteStore.displayInboxDocuments.count == 3)
+    }
+
+    @Test func test_archive_keepsDocumentWhenMoveFails() async {
+        await noteStore.incrementalFetch(directory: .inbox)
+        repositoryMock.moveShouldThrow = true
+        let target = noteStore.displayInboxDocuments[0]
+        noteStore.archive(target)
+        #expect(noteStore.displayInboxDocuments.count == 3)
+        #expect(noteStore.displayArchivedDocuments.isEmpty)
     }
 }
 
@@ -47,6 +75,8 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     }
 
     var documents: [NoteDocument]
+    var failingUrls: Set<URL> = []
+    var moveShouldThrow = false
 
     init(documents: [NoteDocument]) {
         self.documents = documents
@@ -58,13 +88,16 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
 
     @MainActor
     func open(fileUrl: URL) async throws -> NoteDocument {
+        if failingUrls.contains(fileUrl) {
+            throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)
+        }
         switch fileUrl.lastPathComponent {
         case "file1":
-            documents[0]
+            return documents[0]
         case "file2":
-            documents[1]
+            return documents[1]
         case "file3":
-            documents[2]
+            return documents[2]
         default:
             fatalError()
         }
@@ -77,7 +110,10 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     func delete(fileUrl: URL) throws {}
 
     func move(fileUrl: URL, to directory: NoteDirectory) throws -> URL {
-        fileUrl
+        if moveShouldThrow {
+            throw NoteRepositoryError.directoryNotAvailable
+        }
+        return fileUrl
     }
 
     func duplicate(document: NoteDocument, in directory: NoteDirectory) -> NoteDocument? {


### PR DESCRIPTION
## Summary

Eliminates the data-loss paths in the persistence layer found by the technical-debt audit. Corrupt or unwritable files now fail loudly (error alert, rollback) instead of silently destroying notes or hiding them from the list.

Closes #169

## Changes

Commit by commit:

1. **Propagate NoteDocument encode/decode failures**
   - `contents(forType:)`: `(try? encode) ?? Data()` → `try encode`. A failed encode now fails the save instead of overwriting the note with zero bytes.
   - `load(fromContents:)`: print-and-continue → `throw`. A corrupt file now fails `open()` instead of opening as a blank note that would overwrite the original on the next save.
   - New `NoteDocumentTests` (round-trip, garbage data, non-Data contents).
2. **Resolve iCloud conflicts via `stateChangedNotification`**
   - The init-time `documentState == .inConflict` check ran before `open()` and could never be true; replaced with a `UIDocument.stateChangedNotification` observer using `documentState.contains(.inConflict)`.
   - `isResolved = true` is now only set when removing the other versions succeeded.
3. **Tolerate per-file open failures during fetch**
   - `NoteStore.updateDocuments`: `ThrowingTaskGroup` (one bad file discarded the whole batch, empty `catch`) → `withTaskGroup` collecting per-URL results. Readable notes always load.
   - Failed URLs are dropped from the fetch cache so the next fetch retries them (e.g. an iCloud file that finishes downloading later).
   - First real use of `AlertType.error`: the list shows "Failed to load N note(s)".
4. **Report save failures through completion handlers**
   - `NoteRepositoryProtocol.save/duplicate` now take completions; `UIDocument.save` results are no longer ignored.
   - `NoteStore.addTag/removeTag` roll back the entity mutation and alert when the save fails; `duplicate` alerts instead of inserting a phantom note.
   - Canvas: explicit Save in the unsaved-changes dialog only closes the canvas after a successful save; failed saves (including autosave) show a "Failed to save the note" alert.
   - `TagRepository.saveAll` returns `Bool`; `TagStore` reloads from disk when a save fails so the tag list never shows unpersisted state.

Out of scope (follow-ups from the audit): `NSFileCoordinator` for delete/move on iCloud documents, `makeDirectoryIfNeeded` error propagation, and the open-then-close document lifecycle that limits conflict detection to the `open()` window.

## Verification

- `xcodebuild clean test`: TEST SUCCEEDED — 10 tests in 2 suites (4 new NoteDocument tests, 5 new NoteStore tests covering partial failure, retry, move-failure rollback, tag save rollback)
- Simulator: seeded a corrupt `.plist` into `InboxFolder` → app launches, no crash, `showAlert` fires (unit-tested); the alert itself is covered by the auto-opened canvas at launch, which is the pre-existing launch design — verified the identical alert wiring presents correctly via the iCloud-denied case (screenshot below taken on device launch with iCloud unavailable)
- Note list behind the canvas could not be driven end-to-end (no tap driver in the verification environment)
