### PR TITLE
Add privacy manifest, VoiceOver labels, and drop deprecated UIScreen.main

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A6C8DD092D3CEE5400D7D32F /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C8DD082D3CEE5400D7D32F /* Notification+.swift */; };
 		A6CADA51276752E600657E9E /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA50276752E600657E9E /* SettingView.swift */; };
 		A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6DE5BC32437167E006D3D47 /* Assets.xcassets */; };
+		A70000000000000000000019 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000009 /* PrivacyInfo.xcprivacy */; };
 		A6F6ED4B27C77A7500DD3296 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F6ED4A27C77A7500DD3296 /* RootView.swift */; };
 		A6FD03422D3FAD8600224B03 /* NoteListTagHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FD03412D3FAD8600224B03 /* NoteListTagHStack.swift */; };
 		A70000000000000000000011 /* NoteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000001 /* NoteRepository.swift */; };
@@ -92,6 +93,7 @@
 		A6CADA50276752E600657E9E /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		A6DE5BB72437167C006D3D47 /* Pieces of Paper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pieces of Paper.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6DE5BC32437167E006D3D47 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A70000000000000000000009 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A6DE5BC82437167E006D3D47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A6F6ED4A27C77A7500DD3296 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A6FD03412D3FAD8600224B03 /* NoteListTagHStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteListTagHStack.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 				A70000000000000000000021 /* Repository */,
 				A6620E2A2748A05B00C708A2 /* Model */,
 				A6DE5BC32437167E006D3D47 /* Assets.xcassets */,
+				A70000000000000000000009 /* PrivacyInfo.xcprivacy */,
 				A6675A37251D89BA00343151 /* Like Paper.entitlements */,
 				A6DE5BC82437167E006D3D47 /* Info.plist */,
 			);
@@ -368,6 +371,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */,
+				A70000000000000000000019 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PiecesOfPaper/PrivacyInfo.xcprivacy
+++ b/PiecesOfPaper/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -123,6 +123,7 @@ struct CanvasView: View {
             } label: {
                 Image(systemName: "info.circle")
             }
+            .accessibilityLabel("Note Information")
             .popover(isPresented: $canvasViewModel.showDrawingInformation) {
                 NoteInformationView(document: canvasViewModel.document)
             }
@@ -132,6 +133,7 @@ struct CanvasView: View {
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
+            .accessibilityLabel("Share")
             Button(action: done) {
                 Text("Done")
             }

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -14,6 +14,7 @@ import LinkPresentation
 struct CanvasView: View {
     @State var canvasViewModel: CanvasViewModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.displayScale) private var displayScale
     @AppStorage("review_requested") private var reviewRequested = false
     @State private var canvasView = PKCanvasView()
     @State private var toolPicker = PKToolPicker()
@@ -35,12 +36,18 @@ struct CanvasView: View {
     }
 
     var body: some View {
+        GeometryReader { geometry in
+            canvas(windowSize: geometry.size)
+        }
+    }
+
+    private func canvas(windowSize: CGSize) -> some View {
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
                             saveAction: canvasViewModel.save)
         .onAppear {
             canvasView.drawing = canvasViewModel.document.entity.drawing
-            initialContentSize()
+            initialContentSize(windowSize: windowSize)
             hideExceptPaper = true
         }
         .gesture(tapGesture)
@@ -84,25 +91,25 @@ struct CanvasView: View {
 
     // MARK: - Window Adjustment
 
-    private var isDrawingWiderThanWindow: Bool {
-        UIScreen.main.bounds.width < canvasView.drawing.bounds.maxX
+    private func isDrawingWider(than windowSize: CGSize) -> Bool {
+        windowSize.width < canvasView.drawing.bounds.maxX
     }
 
-    private var isDrawingHigherThanWindow: Bool {
-        UIScreen.main.bounds.height < canvasView.drawing.bounds.maxY
+    private func isDrawingHigher(than windowSize: CGSize) -> Bool {
+        windowSize.height < canvasView.drawing.bounds.maxY
     }
 
-    private func initialContentSize() {
+    private func initialContentSize(windowSize: CGSize) {
         guard !canvasView.drawing.bounds.isNull else { return }
 
-        if isDrawingWiderThanWindow, isDrawingHigherThanWindow {
+        if isDrawingWider(than: windowSize), isDrawingHigher(than: windowSize) {
             canvasView.contentSize = .init(width: canvasView.drawing.bounds.maxX,
                                            height: canvasView.drawing.bounds.maxY)
-        } else if isDrawingWiderThanWindow, !isDrawingHigherThanWindow {
+        } else if isDrawingWider(than: windowSize), !isDrawingHigher(than: windowSize) {
             canvasView.contentSize = .init(width: canvasView.drawing.bounds.maxX,
-                                           height: UIScreen.main.bounds.height)
-        } else if !isDrawingWiderThanWindow, isDrawingHigherThanWindow {
-            canvasView.contentSize = .init(width: UIScreen.main.bounds.width,
+                                           height: windowSize.height)
+        } else if !isDrawingWider(than: windowSize), isDrawingHigher(than: windowSize) {
+            canvasView.contentSize = .init(width: windowSize.width,
                                            height: canvasView.drawing.bounds.maxY)
         }
 
@@ -137,7 +144,7 @@ struct CanvasView: View {
         trait.performAsCurrent {
             image = canvasViewModel.document.entity.drawing.image(
                 from: canvasViewModel.document.entity.drawing.bounds,
-                scale: UIScreen.main.scale
+                scale: displayScale
             )
         }
 

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -159,11 +159,13 @@ struct NoteListParentView: View {
             } label: {
                 Image(systemName: "ellipsis.circle")
             }
+            .accessibilityLabel("More Actions")
             Button {
                 noteStore.showCanvasView = true
             } label: {
                 Image(systemName: "square.and.pencil")
             }
+            .accessibilityLabel("New Note")
         }
     }
 
@@ -189,6 +191,7 @@ struct NoteListParentView: View {
                                 action: { scrollToBottom(proxy: proxy) },
                                 image: Image(systemName: "arrow.down.circle")
                             )
+                            .accessibilityLabel("Scroll to Bottom")
                         }
                     }
                 )

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -14,6 +14,7 @@ struct NoteListParentView: View {
     @Environment(TagStore.self) private var tagStore
     @Environment(PreferenceStore.self) private var preferenceStore
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.displayScale) private var displayScale
     @State private var showListOrderSettingView = false
 
     private var isTargetDirectoryArchived: Bool {
@@ -207,7 +208,7 @@ struct NoteListParentView: View {
         var image = UIImage()
         let trait = UITraitCollection(userInterfaceStyle: .light)
         trait.performAsCurrent {
-            image = drawing.image(from: drawing.bounds, scale: UIScreen.main.scale)
+            image = drawing.image(from: drawing.bounds, scale: displayScale)
         }
 
         return UIActivityViewControllerWrapper(activityItems: [image])

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -28,6 +28,7 @@ struct NoteView: View {
                 .background(Color(UIColor.secondarySystemBackground))
                 .shadow(radius: 5)
         })
+        .accessibilityLabel("Note")
         .fullScreenCover(isPresented: $showCanvasView) {
             NavigationView {
                 CanvasView(canvasViewModel: CanvasViewModel(noteDocument: document))

--- a/PiecesOfPaper/View/Tag/AddTagFooter.swift
+++ b/PiecesOfPaper/View/Tag/AddTagFooter.swift
@@ -34,6 +34,8 @@ struct AddTagFooter: View {
         .onTapGesture {
             isTapped.toggle()
         }
+        .accessibilityLabel("Add Tag")
+        .accessibilityAddTraits(.isButton)
         .sheet(isPresented: $isTapped) {
             NavigationView {
                 VStack {


### PR DESCRIPTION
## Summary

App Store / platform-compliance fixes from the technical-debt audit: privacy manifest, VoiceOver labels, and removal of deprecated `UIScreen.main`.

Closes #171

## Changes

1. **Add `PrivacyInfo.xcprivacy`** — declares `NSPrivacyAccessedAPICategoryUserDefaults` with reason `CA92.1` (app-internal UserDefaults access in `PreferenceRepository`); no tracking, no collected data. Registered in the app target's Resources build phase.
2. **Replace deprecated `UIScreen.main`** — `CanvasView` now measures the window through `GeometryReader` for the initial canvas content-size math, and share-image rendering in `CanvasView` / `NoteListParentView` uses the `displayScale` environment value. No behavioral change on single-scene iPhone; correct sizes under iPad multitasking.
3. **Add accessibility labels to icon-only controls** — toolbar menu ("More Actions"), new-note button ("New Note"), canvas info ("Note Information") and share ("Share") buttons, scroll-to-bottom button ("Scroll to Bottom"), add-tag footer ("Add Tag", now also exposed as a button), and note thumbnails ("Note").

## Verification

- `xcodebuild clean test`: TEST SUCCEEDED (10 tests in 2 suites)
- Confirmed `PrivacyInfo.xcprivacy` is copied into the built app bundle (`CpResource` in the build log, contents verified with `plutil`)

## Notes

- The note thumbnail label is a generic "Note"; a date-based label (e.g. "Note, updated July 11") would be better UX but needs a formatting decision — left as a follow-up.
