### PR TITLE
Cache note thumbnails and the iCloud container URL

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A6484FD4272CF10800676ED8 /* UIActivityViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6484FD3272CF10800676ED8 /* UIActivityViewControllerWrapper.swift */; };
 		A6484FD6272E63B000676ED8 /* NoteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6484FD5272E63B000676ED8 /* NoteListView.swift */; };
 		A64AE9F22759A963002C66F7 /* NoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64AE9F12759A963002C66F7 /* NoteView.swift */; };
+		A7000000000000000000001A /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000A /* ThumbnailCache.swift */; };
 		A64AE9F4275B203A002C66F7 /* NoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64AE9F3275B203A002C66F7 /* NoteEntity.swift */; };
 		A6620E2C2748ABE400C708A2 /* CanvasViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E2B2748ABE400C708A2 /* CanvasViewModel.swift */; };
 		A6620E2E274C6E8E00C708A2 /* SideBarListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E2D274C6E8E00C708A2 /* SideBarListView.swift */; };
@@ -76,6 +77,7 @@
 		A6484FD3272CF10800676ED8 /* UIActivityViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityViewControllerWrapper.swift; sourceTree = "<group>"; };
 		A6484FD5272E63B000676ED8 /* NoteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListView.swift; sourceTree = "<group>"; };
 		A64AE9F12759A963002C66F7 /* NoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteView.swift; sourceTree = "<group>"; };
+		A7000000000000000000000A /* ThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		A64AE9F3275B203A002C66F7 /* NoteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEntity.swift; sourceTree = "<group>"; };
 		A6620E2B2748ABE400C708A2 /* CanvasViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasViewModel.swift; sourceTree = "<group>"; };
 		A6620E2D274C6E8E00C708A2 /* SideBarListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideBarListView.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 				A6620E35274C7A3D00C708A2 /* NoteListParentView.swift */,
 				A6484FD5272E63B000676ED8 /* NoteListView.swift */,
 				A64AE9F12759A963002C66F7 /* NoteView.swift */,
+				A7000000000000000000000A /* ThumbnailCache.swift */,
 				A6620E33274C774D00C708A2 /* ScrollButton.swift */,
 				A63C9594276447BD00822461 /* ListOrderSettingView.swift */,
 			);
@@ -418,6 +421,7 @@
 				A63C9586275DB86600822461 /* AddTagView.swift in Sources */,
 				A63C959B2765A5D500822461 /* NoteInformationView.swift in Sources */,
 				A64AE9F22759A963002C66F7 /* NoteView.swift in Sources */,
+				A7000000000000000000001A /* ThumbnailCache.swift in Sources */,
 				A6620E3C274CD88000C708A2 /* FilePath.swift in Sources */,
 				A63C9588275DB97900822461 /* DeletableTag.swift in Sources */,
 				A6620E3A274C8FA400C708A2 /* NoteDocument.swift in Sources */,

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -15,9 +15,17 @@ enum FilePath {
             : documentDirectoryUrl
     }
 
+    // url(forUbiquityContainerIdentifier:) is slow and not meant for the main thread,
+    // but it is called from computed properties all over the app. Resolve it once and reuse.
+    private static var cachediCloudUrl: URL?
     static var iCloudUrl: URL? {
+        if let cachediCloudUrl {
+            return cachediCloudUrl
+        }
         guard let url = FileManager.default.url(forUbiquityContainerIdentifier: nil) else { return nil }
-        return url.appendingPathComponent("Documents")
+        let documentsUrl = url.appendingPathComponent("Documents")
+        cachediCloudUrl = documentsUrl
+        return documentsUrl
     }
 
     static var documentDirectoryUrl: URL? {

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -12,23 +12,29 @@ import PencilKit
 struct NoteView: View {
     private(set) var document: NoteDocument
     @State private var showCanvasView = false
-    @Environment(\.colorScheme) private var colorScheme: ColorScheme
-    private var image: UIImage {
-        document.entity.drawing.image(from: document.entity.drawing.bounds, scale: 1.0)
-    }
+    @State private var thumbnail: UIImage?
 
     var body: some View {
         Button(action: {
             showCanvasView = true
         }, label: {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 250, height: 190)
-                .background(Color(UIColor.secondarySystemBackground))
-                .shadow(radius: 5)
+            Group {
+                if let thumbnail {
+                    Image(uiImage: thumbnail)
+                        .resizable()
+                        .scaledToFit()
+                } else {
+                    Color.clear
+                }
+            }
+            .frame(width: 250, height: 190)
+            .background(Color(UIColor.secondarySystemBackground))
+            .shadow(radius: 5)
         })
         .accessibilityLabel("Note")
+        .task(id: document.entity.updatedDate) {
+            thumbnail = await ThumbnailCache.shared.thumbnail(for: document)
+        }
         .fullScreenCover(isPresented: $showCanvasView) {
             NavigationView {
                 CanvasView(canvasViewModel: CanvasViewModel(noteDocument: document))

--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -1,0 +1,33 @@
+//
+//  ThumbnailCache.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2026/07/11.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import UIKit
+import PencilKit
+
+/// Renders note thumbnails off the main thread and caches them.
+/// The cache key includes updatedDate, so an edited note is re-rendered automatically.
+final class ThumbnailCache {
+    static let shared = ThumbnailCache()
+    private let cache = NSCache<NSString, UIImage>()
+
+    func thumbnail(for document: NoteDocument) async -> UIImage {
+        let key = "\(document.entity.id.uuidString)-\(document.entity.updatedDate.timeIntervalSince1970)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let drawing = document.entity.drawing
+        guard !drawing.bounds.isNull else { return UIImage() }
+
+        let image = await Task.detached(priority: .userInitiated) {
+            drawing.image(from: drawing.bounds, scale: 1.0)
+        }.value
+        cache.setObject(image, forKey: key)
+        return image
+    }
+}


### PR DESCRIPTION
## Summary

Removes the two main-thread hot spots in the note list found by the technical-debt audit: per-row synchronous thumbnail rasterization and repeated iCloud container resolution.

Closes #173

## Changes

1. **Off-main thumbnail rendering with a cache** — new `ThumbnailCache` (`NSCache`-backed) renders `PKDrawing` → `UIImage` in a detached task. `NoteView` loads the thumbnail via `.task(id: updatedDate)` and shows the background color as a placeholder until it arrives. The cache key is `id + updatedDate`, so editing a note re-renders its thumbnail automatically; unchanged notes render once per process instead of once per body evaluation. Also drops the unused `@Environment(\.colorScheme)` property.
2. **Cache the resolved iCloud container URL** — `FilePath.iCloudUrl` now resolves `url(forUbiquityContainerIdentifier:)` once and reuses it. Only a successful resolution is cached, so iCloud becoming available mid-session still gets picked up; signing out mid-session keeps the stale URL, which matches the existing fallback behavior (`iCloudUrl ?? documentDirectoryUrl`).

Not covered (tracked in #173's follow-up note): the list still loads every note's full `PKDrawing` into memory; metadata-only loading needs a document-format change.

## Verification

- `xcodebuild clean test`: TEST SUCCEEDED (10 tests in 2 suites)
- Simulator: installed the build, seeded a note with strokes, launched — app stable with the async thumbnail path active (the note list is in the hierarchy at launch, so `.task` runs); no crash, no regression in launch behavior
