### PR TITLE
Add unit tests for Store-layer persistence

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		A70000000000000000000016 /* PreferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000006 /* PreferenceStore.swift */; };
 		A70000000000000000000017 /* NoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000007 /* NoteStoreTests.swift */; };
 		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
+		A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000B /* PreferenceStoreTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +108,7 @@
 		A70000000000000000000006 /* PreferenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStore.swift; sourceTree = "<group>"; };
 		A70000000000000000000007 /* NoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
+		A7000000000000000000000B /* PreferenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +206,7 @@
 			children = (
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
+				A7000000000000000000000B /* PreferenceStoreTests.swift */,
 				A6A16EC625B1673500DF323F /* Info.plist */,
 			);
 			path = PiecesOfPaperTests;
@@ -408,6 +411,7 @@
 			files = (
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
+				A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		A70000000000000000000017 /* NoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000007 /* NoteStoreTests.swift */; };
 		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
 		A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000B /* PreferenceStoreTests.swift */; };
+		A7000000000000000000001C /* TagStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000C /* TagStoreTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +110,7 @@
 		A70000000000000000000007 /* NoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
 		A7000000000000000000000B /* PreferenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStoreTests.swift; sourceTree = "<group>"; };
+		A7000000000000000000000C /* TagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,6 +209,7 @@
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A7000000000000000000000B /* PreferenceStoreTests.swift */,
+				A7000000000000000000000C /* TagStoreTests.swift */,
 				A6A16EC625B1673500DF323F /* Info.plist */,
 			);
 			path = PiecesOfPaperTests;
@@ -412,6 +415,7 @@
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 				A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */,
+				A7000000000000000000001C /* TagStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -14,13 +14,15 @@ import Testing
 struct NoteStoreTests {
     var noteStore: NoteStore
     let repositoryMock: NoteRepositoryMock
+    let preferenceRepositoryMock: PreferenceRepositoryMock
     let documents = (0...2).map { _ in NoteDocument.createTestData() }
 
     init() {
         repositoryMock = NoteRepositoryMock(documents: documents)
+        preferenceRepositoryMock = PreferenceRepositoryMock()
         noteStore = NoteStore(
             noteRepository: repositoryMock,
-            preferenceRepository: PreferenceRepositoryMock()
+            preferenceRepository: preferenceRepositoryMock
         )
     }
 
@@ -62,6 +64,48 @@ struct NoteStoreTests {
         noteStore.addTag(tag, to: target)
         #expect(target.entity.tags == [tag])
         #expect(!noteStore.showAlert)
+    }
+
+    @Test func test_inboxListOrder_persistsOnChange() {
+        var order = ListOrder()
+        order.sortBy = .createdDate
+        order.sortOrder = .ascending
+        noteStore.inboxListOrder = order
+        #expect(preferenceRepositoryMock.setListOrderCalls.count == 1)
+        let call = preferenceRepositoryMock.setListOrderCalls.first
+        #expect(call?.directoryName == NoteDirectory.inbox.rawValue)
+        #expect(call?.listOrder.sortBy == .createdDate)
+        #expect(call?.listOrder.sortOrder == .ascending)
+    }
+
+    @Test func test_archivedListOrder_persistsOnChange() {
+        var order = ListOrder()
+        order.sortOrder = .ascending
+        noteStore.archivedListOrder = order
+        #expect(preferenceRepositoryMock.setListOrderCalls.count == 1)
+        let call = preferenceRepositoryMock.setListOrderCalls.first
+        #expect(call?.directoryName == NoteDirectory.archived.rawValue)
+        #expect(call?.listOrder.sortOrder == .ascending)
+    }
+
+    @Test func test_init_restoresListOrdersWithoutRePersisting() {
+        let preferenceMock = PreferenceRepositoryMock()
+        var inboxOrder = ListOrder()
+        inboxOrder.sortBy = .createdDate
+        var archivedOrder = ListOrder()
+        archivedOrder.sortOrder = .ascending
+        preferenceMock.listOrders = [
+            NoteDirectory.inbox.rawValue: inboxOrder,
+            NoteDirectory.archived.rawValue: archivedOrder
+        ]
+
+        let store = NoteStore(
+            noteRepository: NoteRepositoryMock(documents: []),
+            preferenceRepository: preferenceMock
+        )
+        #expect(store.inboxListOrder.sortBy == .createdDate)
+        #expect(store.archivedListOrder.sortOrder == .ascending)
+        #expect(preferenceMock.setListOrderCalls.isEmpty)
     }
 
     @Test func test_addTag_rollsBackTagWhenSaveFails() async {
@@ -142,13 +186,43 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     }
 }
 
-struct PreferenceRepositoryMock: PreferenceRepositoryProtocol {
-    func getEnablediCloud() -> Bool { false }
-    func setEnablediCloud(_ value: Bool) {}
-    func getEnabledAutoSave() -> Bool { true }
-    func setEnabledAutoSave(_ value: Bool) {}
-    func getEnabledInfiniteScroll() -> Bool { true }
-    func setEnabledInfiniteScroll(_ value: Bool) {}
-    func getListOrder(directoryName: String) -> ListOrder { ListOrder() }
-    func setListOrder(directoryName: String, listOrder: ListOrder) {}
+final class PreferenceRepositoryMock: PreferenceRepositoryProtocol {
+    var enablediCloud = false
+    var enabledAutoSave = true
+    var enabledInfiniteScroll = true
+    var listOrders: [String: ListOrder] = [:]
+    private(set) var setEnablediCloudCalls: [Bool] = []
+    private(set) var setEnabledAutoSaveCalls: [Bool] = []
+    private(set) var setEnabledInfiniteScrollCalls: [Bool] = []
+    private(set) var setListOrderCalls: [(directoryName: String, listOrder: ListOrder)] = []
+
+    func getEnablediCloud() -> Bool { enablediCloud }
+
+    func setEnablediCloud(_ value: Bool) {
+        enablediCloud = value
+        setEnablediCloudCalls.append(value)
+    }
+
+    func getEnabledAutoSave() -> Bool { enabledAutoSave }
+
+    func setEnabledAutoSave(_ value: Bool) {
+        enabledAutoSave = value
+        setEnabledAutoSaveCalls.append(value)
+    }
+
+    func getEnabledInfiniteScroll() -> Bool { enabledInfiniteScroll }
+
+    func setEnabledInfiniteScroll(_ value: Bool) {
+        enabledInfiniteScroll = value
+        setEnabledInfiniteScrollCalls.append(value)
+    }
+
+    func getListOrder(directoryName: String) -> ListOrder {
+        listOrders[directoryName] ?? ListOrder()
+    }
+
+    func setListOrder(directoryName: String, listOrder: ListOrder) {
+        listOrders[directoryName] = listOrder
+        setListOrderCalls.append((directoryName, listOrder))
+    }
 }

--- a/PiecesOfPaperTests/PreferenceStoreTests.swift
+++ b/PiecesOfPaperTests/PreferenceStoreTests.swift
@@ -1,0 +1,59 @@
+//
+//  PreferenceStoreTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/18.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Testing
+@testable import Pieces_of_Paper
+
+@MainActor
+struct PreferenceStoreTests {
+    @Test func test_init_readsValuesWithoutRePersisting() {
+        let mock = PreferenceRepositoryMock()
+        mock.enablediCloud = true
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = false
+
+        let store = PreferenceStore(repository: mock)
+        #expect(store.enablediCloud)
+        #expect(!store.enabledAutoSave)
+        #expect(!store.enabledInfiniteScroll)
+        #expect(mock.setEnablediCloudCalls.isEmpty)
+        #expect(mock.setEnabledAutoSaveCalls.isEmpty)
+        #expect(mock.setEnabledInfiniteScrollCalls.isEmpty)
+    }
+
+    @Test func test_enablediCloud_persistsOnChange() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        store.enablediCloud = true
+        #expect(mock.setEnablediCloudCalls == [true])
+        #expect(mock.getEnablediCloud())
+    }
+
+    @Test func test_enabledAutoSave_persistsOnChange() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        store.enabledAutoSave = false
+        #expect(mock.setEnabledAutoSaveCalls == [false])
+        #expect(!mock.getEnabledAutoSave())
+    }
+
+    @Test func test_enabledInfiniteScroll_persistsOnChange() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        store.enabledInfiniteScroll = false
+        #expect(mock.setEnabledInfiniteScrollCalls == [false])
+        #expect(!mock.getEnabledInfiniteScroll())
+    }
+
+    @Test func test_shouldGrantiCloud_isFalseWheniCloudDisabled() {
+        let mock = PreferenceRepositoryMock()
+        mock.enablediCloud = false
+        let store = PreferenceStore(repository: mock)
+        #expect(!store.shouldGrantiCloud)
+    }
+}

--- a/PiecesOfPaperTests/TagStoreTests.swift
+++ b/PiecesOfPaperTests/TagStoreTests.swift
@@ -1,0 +1,84 @@
+//
+//  TagStoreTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/18.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import UIKit
+import Testing
+@testable import Pieces_of_Paper
+
+@MainActor
+struct TagStoreTests {
+    let initialTags = [
+        TagEntity(name: "idea", color: CodableUIColor(uiColor: .systemYellow)),
+        TagEntity(name: "memo", color: CodableUIColor(uiColor: .systemBlue))
+    ]
+    let repositoryMock: TagRepositoryMock
+    let tagStore: TagStore
+
+    init() {
+        repositoryMock = TagRepositoryMock(tags: initialTags)
+        tagStore = TagStore(repository: repositoryMock)
+    }
+
+    @Test func test_init_loadsTagsFromRepository() {
+        #expect(tagStore.tags == initialTags)
+    }
+
+    @Test func test_add_appendsAndPersists() {
+        let tag = TagEntity(name: "new", color: CodableUIColor(uiColor: .systemRed))
+        tagStore.add(tag)
+        #expect(tagStore.tags == initialTags + [tag])
+        #expect(repositoryMock.saveAllCalls.last == initialTags + [tag])
+    }
+
+    @Test func test_add_rollsBackWhenSaveFails() {
+        repositoryMock.saveShouldSucceed = false
+        let tag = TagEntity(name: "new", color: CodableUIColor(uiColor: .systemRed))
+        tagStore.add(tag)
+        #expect(tagStore.tags == initialTags)
+    }
+
+    @Test func test_remove_removesAndPersists() {
+        tagStore.remove(initialTags[0])
+        #expect(tagStore.tags == [initialTags[1]])
+        #expect(repositoryMock.saveAllCalls.last == [initialTags[1]])
+    }
+
+    @Test func test_removeAtOffsets_removesAndPersists() {
+        tagStore.remove(at: IndexSet(integer: 1))
+        #expect(tagStore.tags == [initialTags[0]])
+        #expect(repositoryMock.saveAllCalls.last == [initialTags[0]])
+    }
+
+    @Test func test_remove_rollsBackWhenSaveFails() {
+        repositoryMock.saveShouldSucceed = false
+        tagStore.remove(initialTags[0])
+        #expect(tagStore.tags == initialTags)
+    }
+}
+
+final class TagRepositoryMock: TagRepositoryProtocol {
+    var storedTags: [TagEntity]
+    var saveShouldSucceed = true
+    private(set) var saveAllCalls: [[TagEntity]] = []
+
+    init(tags: [TagEntity]) {
+        storedTags = tags
+    }
+
+    func fetchAll() -> [TagEntity] {
+        storedTags
+    }
+
+    @discardableResult
+    func saveAll(_ tags: [TagEntity]) -> Bool {
+        saveAllCalls.append(tags)
+        guard saveShouldSucceed else { return false }
+        storedTags = tags
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the Store-layer persistence paths that were left uncovered after the Store/Repository migration (#168). No production code is changed — the diff is test files plus their `project.pbxproj` registration.

Closes #177

## Changes

- `NoteStoreTests`: upgraded `PreferenceRepositoryMock` from a no-op struct to a recording spy, and added three tests — `inboxListOrder` / `archivedListOrder` `didSet` persistence (the regression path from #158) and init-time restore without re-persisting
- `PreferenceStoreTests` (new): init reads values without triggering setters, each of the three `didSet` persistence paths (`enablediCloud`, `enabledAutoSave`, `enabledInfiniteScroll`), and `shouldGrantiCloud == false` when iCloud is disabled
- `TagStoreTests` (new): init load, `add` / `remove(_:)` / `remove(at:)` persistence via `saveAll`, and rollback-to-repository-state when a save fails
- `project.pbxproj`: registered the two new test files in the `PiecesOfPaperTests` target

## Verification

- `xcodebuild clean test` (iPhone SE 3rd gen simulator): **TEST SUCCEEDED** — 24 tests in 4 suites passed (14 of them new)
