### PR TITLE
Separate NoteDocument responsibilities: file I/O vs view state

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
 		A70000000000000000000041 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000031 /* NoteData.swift */; };
 		A70000000000000000000042 /* NoteDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000032 /* NoteDataTests.swift */; };
+		A70000000000000000000043 /* CanvasViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000033 /* CanvasViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000033 /* CanvasViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,6 +209,7 @@
 		A6A16EC325B1673500DF323F /* PiecesOfPaperTests */ = {
 			isa = PBXGroup;
 			children = (
+				A70000000000000000000033 /* CanvasViewModelTests.swift */,
 				A70000000000000000000032 /* NoteDataTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
@@ -412,6 +415,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A70000000000000000000043 /* CanvasViewModelTests.swift in Sources */,
 				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		A70000000000000000000016 /* PreferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000006 /* PreferenceStore.swift */; };
 		A70000000000000000000017 /* NoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000007 /* NoteStoreTests.swift */; };
 		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
+		A70000000000000000000041 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000031 /* NoteData.swift */; };
+		A70000000000000000000042 /* NoteDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000032 /* NoteDataTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +109,8 @@
 		A70000000000000000000006 /* PreferenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStore.swift; sourceTree = "<group>"; };
 		A70000000000000000000007 /* NoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
+		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +158,7 @@
 				A6C8DD082D3CEE5400D7D32F /* Notification+.swift */,
 				A6620E3B274CD88000C708A2 /* FilePath.swift */,
 				A63C9592276444CF00822461 /* ListOrder.swift */,
+				A70000000000000000000031 /* NoteData.swift */,
 				A6620E39274C8FA400C708A2 /* NoteDocument.swift */,
 				A64AE9F3275B203A002C66F7 /* NoteEntity.swift */,
 				A63C956C275C7CF300822461 /* TagEntity.swift */,
@@ -202,6 +207,7 @@
 		A6A16EC325B1673500DF323F /* PiecesOfPaperTests */ = {
 			isa = PBXGroup;
 			children = (
+				A70000000000000000000032 /* NoteDataTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A6A16EC625B1673500DF323F /* Info.plist */,
@@ -406,6 +412,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 			);
@@ -443,6 +450,7 @@
 				A63C95972764589F00822461 /* ListOrderSettingViewModel.swift in Sources */,
 				A6620E2E274C6E8E00C708A2 /* SideBarListView.swift in Sources */,
 				A6484FD6272E63B000676ED8 /* NoteListView.swift in Sources */,
+				A70000000000000000000041 /* NoteData.swift in Sources */,
 				A64AE9F4275B203A002C66F7 /* NoteEntity.swift in Sources */,
 				A6620E36274C7A3D00C708A2 /* NoteListParentView.swift in Sources */,
 				A70000000000000000000011 /* NoteRepository.swift in Sources */,

--- a/PiecesOfPaper/Model/NoteData.swift
+++ b/PiecesOfPaper/Model/NoteData.swift
@@ -1,0 +1,32 @@
+//
+//  NoteData.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2026/07/18.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+import PencilKit
+
+struct NoteData: Identifiable, Equatable {
+    var entity: NoteEntity
+    let fileURL: URL
+
+    var id: UUID { entity.id }
+
+    var isArchived: Bool {
+        guard let archivedUrl = FilePath.archivedUrl else { return false }
+        return fileURL.path.hasPrefix(archivedUrl.path)
+    }
+}
+
+extension NoteData {
+    static func createTestData() -> NoteData {
+        guard let url = URL(string: "file:///test") else {
+            fatalError()
+        }
+
+        return NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: url)
+    }
+}

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -80,6 +80,13 @@ final class NoteDocument: UIDocument, Identifiable {
     }
 }
 
+// Temporary bridge while views migrate from NoteDocument to NoteData (#160)
+extension NoteDocument {
+    var noteData: NoteData {
+        NoteData(entity: entity, fileURL: fileURL)
+    }
+}
+
 enum NoteDocumentError: LocalizedError {
     case invalidContents
 

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -80,13 +80,6 @@ final class NoteDocument: UIDocument, Identifiable {
     }
 }
 
-// Temporary bridge while views migrate from NoteDocument to NoteData (#160)
-extension NoteDocument {
-    var noteData: NoteData {
-        NoteData(entity: entity, fileURL: fileURL)
-    }
-}
-
 enum NoteDocumentError: LocalizedError {
     case invalidContents
 

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -9,15 +9,9 @@
 import UIKit
 import PencilKit
 
-final class NoteDocument: UIDocument, Identifiable {
+final class NoteDocument: UIDocument {
     var entity: NoteEntity
-    var id: UUID { entity.id }
     private var stateObserver: NSObjectProtocol?
-
-    var isArchived: Bool {
-        guard let archivedUrl = FilePath.archivedUrl else { return false }
-        return fileURL.path.hasPrefix(archivedUrl.path)
-    }
 
     override init(fileURL: URL) {
         self.entity = NoteEntity(drawing: PKDrawing())
@@ -71,13 +65,6 @@ final class NoteDocument: UIDocument, Identifiable {
         }
     }
 
-    static func createTestData() -> NoteDocument {
-        guard let url = URL(string: "file:///test") else {
-            fatalError()
-        }
-
-        return NoteDocument(fileURL: url, entity: NoteEntity(drawing: PKDrawing()))
-    }
 }
 
 enum NoteDocumentError: LocalizedError {

--- a/PiecesOfPaper/Model/NoteEntity.swift
+++ b/PiecesOfPaper/Model/NoteEntity.swift
@@ -9,7 +9,7 @@
 import Foundation
 import PencilKit
 
-struct NoteEntity: Codable {
+struct NoteEntity: Codable, Equatable {
     var id = UUID()
     var drawing: PKDrawing
     var tags: [TagEntity]

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -21,13 +21,12 @@ enum NoteDirectory: String {
 
 protocol NoteRepositoryProtocol: AnyObject {
     func getFileUrls(directory: NoteDirectory) -> [URL]
-    @MainActor func open(fileUrl: URL) async throws -> NoteDocument
-    func save(document: NoteDocument, completion: @escaping (Bool) -> Void)
+    @MainActor func open(fileUrl: URL) async throws -> NoteData
     func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void)
     func delete(fileUrl: URL) throws
     func move(fileUrl: URL, to directory: NoteDirectory) throws -> URL
-    func duplicate(document: NoteDocument, in directory: NoteDirectory,
-                   completion: @escaping (NoteDocument?) -> Void)
+    func duplicate(_ note: NoteData, in directory: NoteDirectory,
+                   completion: @escaping (NoteData?) -> Void)
 }
 
 final class NoteRepository: NoteRepositoryProtocol {
@@ -39,7 +38,7 @@ final class NoteRepository: NoteRepositoryProtocol {
     }
 
     @MainActor
-    func open(fileUrl: URL) async throws -> NoteDocument {
+    func open(fileUrl: URL) async throws -> NoteData {
         guard FileManager.default.fileExists(atPath: fileUrl.path) else {
             throw NoteRepositoryError.fileNotExist(path: fileUrl.path)
         }
@@ -47,23 +46,19 @@ final class NoteRepository: NoteRepositoryProtocol {
         let isSuccess = await document.open()
         await document.close()
         if isSuccess {
-            return document
+            return NoteData(entity: document.entity, fileURL: fileUrl)
         } else {
             throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)
         }
-    }
-
-    func save(document: NoteDocument, completion: @escaping (Bool) -> Void) {
-        let saveOperation: UIDocument.SaveOperation =
-            FileManager.default.fileExists(atPath: document.fileURL.path) ? .forOverwriting : .forCreating
-        document.save(to: document.fileURL, for: saveOperation, completionHandler: completion)
     }
 
     func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void) {
         // The transient document lives until the completion handler fires,
         // which keeps its conflict observer active for the whole save.
         let document = NoteDocument(fileURL: fileUrl, entity: entity)
-        save(document: document, completion: completion)
+        let saveOperation: UIDocument.SaveOperation =
+            FileManager.default.fileExists(atPath: fileUrl.path) ? .forOverwriting : .forCreating
+        document.save(to: fileUrl, for: saveOperation, completionHandler: completion)
     }
 
     func delete(fileUrl: URL) throws {
@@ -79,17 +74,17 @@ final class NoteRepository: NoteRepositoryProtocol {
         return toUrl
     }
 
-    func duplicate(document: NoteDocument, in directory: NoteDirectory,
-                   completion: @escaping (NoteDocument?) -> Void) {
+    func duplicate(_ note: NoteData, in directory: NoteDirectory,
+                   completion: @escaping (NoteData?) -> Void) {
         guard let directoryUrl = directory.url else {
             completion(nil)
             return
         }
         let newUrl = directoryUrl.appendingPathComponent(FilePath.fileName)
-        let entity = NoteEntity(drawing: document.entity.drawing)
+        let entity = NoteEntity(drawing: note.entity.drawing)
         let newDocument = NoteDocument(fileURL: newUrl, entity: entity)
         newDocument.save(to: newUrl, for: .forCreating) { success in
-            completion(success ? newDocument : nil)
+            completion(success ? NoteData(entity: entity, fileURL: newUrl) : nil)
         }
     }
 }

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -23,6 +23,7 @@ protocol NoteRepositoryProtocol: AnyObject {
     func getFileUrls(directory: NoteDirectory) -> [URL]
     @MainActor func open(fileUrl: URL) async throws -> NoteDocument
     func save(document: NoteDocument, completion: @escaping (Bool) -> Void)
+    func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void)
     func delete(fileUrl: URL) throws
     func move(fileUrl: URL, to directory: NoteDirectory) throws -> URL
     func duplicate(document: NoteDocument, in directory: NoteDirectory,
@@ -56,6 +57,13 @@ final class NoteRepository: NoteRepositoryProtocol {
         let saveOperation: UIDocument.SaveOperation =
             FileManager.default.fileExists(atPath: document.fileURL.path) ? .forOverwriting : .forCreating
         document.save(to: document.fileURL, for: saveOperation, completionHandler: completion)
+    }
+
+    func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void) {
+        // The transient document lives until the completion handler fires,
+        // which keeps its conflict observer active for the whole save.
+        let document = NoteDocument(fileURL: fileUrl, entity: entity)
+        save(document: document, completion: completion)
     }
 
     func delete(fileUrl: URL) throws {

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -12,8 +12,8 @@ import Foundation
 @MainActor
 final class NoteStore {
     // MARK: - Primary data (Single Source of Truth)
-    private(set) var inboxDocuments = [NoteDocument]()
-    private(set) var archivedDocuments = [NoteDocument]()
+    private(set) var inboxNotes = [NoteData]()
+    private(set) var archivedNotes = [NoteData]()
 
     // MARK: - Sort & filter settings (auto-persist on change)
     var inboxListOrder: ListOrder {
@@ -32,8 +32,8 @@ final class NoteStore {
     var showCanvasView = false
     var showAlert = false
     var alertType: AlertType?
-    var documentToShare: NoteDocument?
-    var documentToTag: NoteDocument?
+    var noteToShare: NoteData?
+    var noteToTag: NoteData?
 
     enum AlertType {
         case iCloudDenied, archive, error(Error)
@@ -55,20 +55,20 @@ final class NoteStore {
         self.archivedListOrder = preferenceRepository.getListOrder(directoryName: NoteDirectory.archived.rawValue)
     }
 
-    // MARK: - Computed display documents (replaces dual-management)
+    // MARK: - Computed display notes (replaces dual-management)
 
-    var displayInboxDocuments: [NoteDocument] {
-        reorderDocuments(inboxDocuments, listOrder: inboxListOrder)
+    var displayInboxNotes: [NoteData] {
+        reorderNotes(inboxNotes, listOrder: inboxListOrder)
     }
 
-    var displayArchivedDocuments: [NoteDocument] {
-        reorderDocuments(archivedDocuments, listOrder: archivedListOrder)
+    var displayArchivedNotes: [NoteData] {
+        reorderNotes(archivedNotes, listOrder: archivedListOrder)
     }
 
-    func displayDocuments(for directory: NoteDirectory) -> [NoteDocument] {
+    func displayNotes(for directory: NoteDirectory) -> [NoteData] {
         switch directory {
-        case .inbox: displayInboxDocuments
-        case .archived: displayArchivedDocuments
+        case .inbox: displayInboxNotes
+        case .archived: displayArchivedNotes
         }
     }
 
@@ -92,16 +92,16 @@ final class NoteStore {
         defer { isLoading = false }
         isLoading = true
         let (added, removed) = fetchChangedFileUrls(directory: directory)
-        await updateDocuments(addedUrls: added, removedUrls: removed, directory: directory)
+        await updateNotes(addedUrls: added, removedUrls: removed, directory: directory)
     }
 
     func reload(directory: NoteDirectory) async {
         switch directory {
         case .inbox:
-            inboxDocuments.removeAll()
+            inboxNotes.removeAll()
             inboxCachedUrls.removeAll()
         case .archived:
-            archivedDocuments.removeAll()
+            archivedNotes.removeAll()
             archivedCachedUrls.removeAll()
         }
         await incrementalFetch(directory: directory)
@@ -123,42 +123,42 @@ final class NoteStore {
         return (Array(added), Array(removed))
     }
 
-    private func updateDocuments(addedUrls: [URL], removedUrls: [URL], directory: NoteDirectory) async {
-        let (newDocuments, failedUrls) = await withTaskGroup(
+    private func updateNotes(addedUrls: [URL], removedUrls: [URL], directory: NoteDirectory) async {
+        let (newNotes, failedUrls) = await withTaskGroup(
             of: (url: URL, note: NoteData?).self
-        ) { group -> ([NoteDocument], [URL]) in
+        ) { group -> ([NoteData], [URL]) in
             for url in addedUrls {
                 group.addTask {
                     (url, try? await self.noteRepository.open(fileUrl: url))
                 }
             }
 
-            var documents: [NoteDocument] = []
+            var notes: [NoteData] = []
             var failed: [URL] = []
             for await result in group {
                 if let note = result.note {
-                    documents.append(NoteDocument(fileURL: note.fileURL, entity: note.entity))
+                    notes.append(note)
                 } else {
                     failed.append(result.url)
                 }
             }
 
-            return (documents, failed)
+            return (notes, failed)
         }
 
         switch directory {
         case .inbox:
-            inboxDocuments += newDocuments
+            inboxNotes += newNotes
             // Drop failed URLs from the cache so the next fetch retries them
             inboxCachedUrls.removeAll { failedUrls.contains($0) }
             removedUrls.forEach { url in
-                inboxDocuments.removeAll { $0.fileURL == url }
+                inboxNotes.removeAll { $0.fileURL == url }
             }
         case .archived:
-            archivedDocuments += newDocuments
+            archivedNotes += newNotes
             archivedCachedUrls.removeAll { failedUrls.contains($0) }
             removedUrls.forEach { url in
-                archivedDocuments.removeAll { $0.fileURL == url }
+                archivedNotes.removeAll { $0.fileURL == url }
             }
         }
 
@@ -170,7 +170,7 @@ final class NoteStore {
 
     // MARK: - Reorder helper
 
-    private func reorderDocuments(_ notes: [NoteDocument], listOrder: ListOrder) -> [NoteDocument] {
+    private func reorderNotes(_ notes: [NoteData], listOrder: ListOrder) -> [NoteData] {
         var filtered = notes
         listOrder.filterBy.forEach { filteringTag in
             filtered = filtered.filter { $0.entity.tags.contains(filteringTag) }
@@ -196,100 +196,95 @@ final class NoteStore {
 
     // MARK: - Data operations
 
-    func duplicate(_ document: NoteDocument, in directory: NoteDirectory) {
-        noteRepository.duplicate(document.noteData, in: directory) { [weak self] newNote in
+    func duplicate(_ note: NoteData, in directory: NoteDirectory) {
+        noteRepository.duplicate(note, in: directory) { [weak self] newNote in
             guard let self else { return }
             guard let newNote else {
                 self.alertType = .error(NoteStoreError.saveFailed)
                 self.showAlert = true
                 return
             }
-            let newDocument = NoteDocument(fileURL: newNote.fileURL, entity: newNote.entity)
             switch directory {
             case .inbox:
-                self.inboxCachedUrls.append(newDocument.fileURL)
-                self.inboxDocuments.append(newDocument)
+                self.inboxCachedUrls.append(newNote.fileURL)
+                self.inboxNotes.append(newNote)
             case .archived:
-                self.archivedCachedUrls.append(newDocument.fileURL)
-                self.archivedDocuments.append(newDocument)
+                self.archivedCachedUrls.append(newNote.fileURL)
+                self.archivedNotes.append(newNote)
             }
         }
     }
 
-    func delete(_ document: NoteDocument) {
+    func delete(_ note: NoteData) {
         do {
-            try noteRepository.delete(fileUrl: document.fileURL)
-            removeDocumentFromArrays(document)
+            try noteRepository.delete(fileUrl: note.fileURL)
+            removeNoteFromArrays(note)
         } catch {
             alertType = .error(NoteStoreError.deleteFailed)
             showAlert = true
         }
     }
 
-    func archive(_ document: NoteDocument) {
+    func archive(_ note: NoteData) {
         do {
-            let newUrl = try noteRepository.move(fileUrl: document.fileURL, to: .archived)
-            // Remove from inbox
-            inboxCachedUrls.removeAll { $0 == document.fileURL }
-            inboxDocuments.removeAll { $0.entity.id == document.entity.id }
-            // Add to archived
-            let archivedDocument = NoteDocument(fileURL: newUrl, entity: document.entity)
+            let newUrl = try noteRepository.move(fileUrl: note.fileURL, to: .archived)
+            inboxCachedUrls.removeAll { $0 == note.fileURL }
+            inboxNotes.removeAll { $0.id == note.id }
             archivedCachedUrls.append(newUrl)
-            archivedDocuments.append(archivedDocument)
+            archivedNotes.append(NoteData(entity: note.entity, fileURL: newUrl))
         } catch {
             print("Could not archive: ", error.localizedDescription)
         }
     }
 
-    func unarchive(_ document: NoteDocument) {
+    func unarchive(_ note: NoteData) {
         do {
-            let newUrl = try noteRepository.move(fileUrl: document.fileURL, to: .inbox)
-            // Remove from archived
-            archivedCachedUrls.removeAll { $0 == document.fileURL }
-            archivedDocuments.removeAll { $0.entity.id == document.entity.id }
-            // Add to inbox
-            let inboxDocument = NoteDocument(fileURL: newUrl, entity: document.entity)
+            let newUrl = try noteRepository.move(fileUrl: note.fileURL, to: .inbox)
+            archivedCachedUrls.removeAll { $0 == note.fileURL }
+            archivedNotes.removeAll { $0.id == note.id }
             inboxCachedUrls.append(newUrl)
-            inboxDocuments.append(inboxDocument)
+            inboxNotes.append(NoteData(entity: note.entity, fileURL: newUrl))
         } catch {
             print("Could not unarchive: ", error.localizedDescription)
         }
     }
 
     func allArchive() {
-        let documents = inboxDocuments
-        documents.forEach { archive($0) }
+        let notes = inboxNotes
+        notes.forEach { archive($0) }
     }
 
     func allUnarchive() {
-        let documents = archivedDocuments
-        documents.forEach { unarchive($0) }
+        let notes = archivedNotes
+        notes.forEach { unarchive($0) }
     }
 
     // MARK: - Tag operations on notes
 
-    func addTag(_ tag: TagEntity, to document: NoteDocument) {
-        document.entity.tags.append(tag)
-        noteRepository.save(document.entity, to: document.fileURL) { [weak self] success in
+    func addTag(_ tag: TagEntity, to note: NoteData) {
+        guard let current = self.note(id: note.id) else { return }
+        var updated = current
+        updated.entity.tags.append(tag)
+        replace(updated)
+        noteRepository.save(updated.entity, to: updated.fileURL) { [weak self] success in
             guard let self else { return }
-            if success {
-                self.updateDocumentInArray(document)
-            } else {
-                document.entity.tags.removeAll { $0 == tag }
+            if !success {
+                self.replace(current)
                 self.alertType = .error(NoteStoreError.saveFailed)
                 self.showAlert = true
             }
         }
     }
 
-    func removeTag(_ tag: TagEntity, from document: NoteDocument) {
-        document.entity.tags.removeAll { $0 == tag }
-        noteRepository.save(document.entity, to: document.fileURL) { [weak self] success in
+    func removeTag(_ tag: TagEntity, from note: NoteData) {
+        guard let current = self.note(id: note.id) else { return }
+        var updated = current
+        updated.entity.tags.removeAll { $0 == tag }
+        replace(updated)
+        noteRepository.save(updated.entity, to: updated.fileURL) { [weak self] success in
             guard let self else { return }
-            if success {
-                self.updateDocumentInArray(document)
-            } else {
-                document.entity.tags.append(tag)
+            if !success {
+                self.replace(current)
                 self.alertType = .error(NoteStoreError.saveFailed)
                 self.showAlert = true
             }
@@ -299,44 +294,37 @@ final class NoteStore {
     // MARK: - Note lookup & write-back
 
     func note(id: UUID) -> NoteData? {
-        let document = inboxDocuments.first { $0.entity.id == id }
-            ?? archivedDocuments.first { $0.entity.id == id }
-        return document?.noteData
+        inboxNotes.first { $0.id == id } ?? archivedNotes.first { $0.id == id }
     }
 
     func upsert(_ note: NoteData) {
-        if let document = inboxDocuments.first(where: { $0.entity.id == note.id })
-            ?? archivedDocuments.first(where: { $0.entity.id == note.id }) {
-            document.entity = note.entity
-            updateDocumentInArray(document)
+        if self.note(id: note.id) != nil {
+            replace(note)
+        } else if note.isArchived {
+            archivedCachedUrls.append(note.fileURL)
+            archivedNotes.append(note)
         } else {
-            let document = NoteDocument(fileURL: note.fileURL, entity: note.entity)
-            if note.isArchived {
-                archivedCachedUrls.append(note.fileURL)
-                archivedDocuments.append(document)
-            } else {
-                inboxCachedUrls.append(note.fileURL)
-                inboxDocuments.append(document)
-            }
+            inboxCachedUrls.append(note.fileURL)
+            inboxNotes.append(note)
         }
     }
 
     // MARK: - Private helpers
 
-    private func updateDocumentInArray(_ document: NoteDocument) {
-        if let idx = inboxDocuments.firstIndex(where: { $0.entity.id == document.entity.id }) {
-            inboxDocuments[idx] = document
+    private func replace(_ note: NoteData) {
+        if let idx = inboxNotes.firstIndex(where: { $0.id == note.id }) {
+            inboxNotes[idx] = note
         }
-        if let idx = archivedDocuments.firstIndex(where: { $0.entity.id == document.entity.id }) {
-            archivedDocuments[idx] = document
+        if let idx = archivedNotes.firstIndex(where: { $0.id == note.id }) {
+            archivedNotes[idx] = note
         }
     }
 
-    private func removeDocumentFromArrays(_ document: NoteDocument) {
-        inboxCachedUrls.removeAll { $0 == document.fileURL }
-        archivedCachedUrls.removeAll { $0 == document.fileURL }
-        inboxDocuments.removeAll { $0.entity.id == document.entity.id }
-        archivedDocuments.removeAll { $0.entity.id == document.entity.id }
+    private func removeNoteFromArrays(_ note: NoteData) {
+        inboxCachedUrls.removeAll { $0 == note.fileURL }
+        archivedCachedUrls.removeAll { $0 == note.fileURL }
+        inboxNotes.removeAll { $0.id == note.id }
+        archivedNotes.removeAll { $0.id == note.id }
     }
 }
 

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -125,7 +125,7 @@ final class NoteStore {
 
     private func updateDocuments(addedUrls: [URL], removedUrls: [URL], directory: NoteDirectory) async {
         let (newDocuments, failedUrls) = await withTaskGroup(
-            of: (url: URL, document: NoteDocument?).self
+            of: (url: URL, note: NoteData?).self
         ) { group -> ([NoteDocument], [URL]) in
             for url in addedUrls {
                 group.addTask {
@@ -136,8 +136,8 @@ final class NoteStore {
             var documents: [NoteDocument] = []
             var failed: [URL] = []
             for await result in group {
-                if let document = result.document {
-                    documents.append(document)
+                if let note = result.note {
+                    documents.append(NoteDocument(fileURL: note.fileURL, entity: note.entity))
                 } else {
                     failed.append(result.url)
                 }
@@ -197,13 +197,14 @@ final class NoteStore {
     // MARK: - Data operations
 
     func duplicate(_ document: NoteDocument, in directory: NoteDirectory) {
-        noteRepository.duplicate(document: document, in: directory) { [weak self] newDocument in
+        noteRepository.duplicate(document.noteData, in: directory) { [weak self] newNote in
             guard let self else { return }
-            guard let newDocument else {
+            guard let newNote else {
                 self.alertType = .error(NoteStoreError.saveFailed)
                 self.showAlert = true
                 return
             }
+            let newDocument = NoteDocument(fileURL: newNote.fileURL, entity: newNote.entity)
             switch directory {
             case .inbox:
                 self.inboxCachedUrls.append(newDocument.fileURL)
@@ -269,7 +270,7 @@ final class NoteStore {
 
     func addTag(_ tag: TagEntity, to document: NoteDocument) {
         document.entity.tags.append(tag)
-        noteRepository.save(document: document) { [weak self] success in
+        noteRepository.save(document.entity, to: document.fileURL) { [weak self] success in
             guard let self else { return }
             if success {
                 self.updateDocumentInArray(document)
@@ -283,7 +284,7 @@ final class NoteStore {
 
     func removeTag(_ tag: TagEntity, from document: NoteDocument) {
         document.entity.tags.removeAll { $0 == tag }
-        noteRepository.save(document: document) { [weak self] success in
+        noteRepository.save(document.entity, to: document.fileURL) { [weak self] success in
             guard let self else { return }
             if success {
                 self.updateDocumentInArray(document)

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -295,6 +295,31 @@ final class NoteStore {
         }
     }
 
+    // MARK: - Note lookup & write-back
+
+    func note(id: UUID) -> NoteData? {
+        let document = inboxDocuments.first { $0.entity.id == id }
+            ?? archivedDocuments.first { $0.entity.id == id }
+        return document?.noteData
+    }
+
+    func upsert(_ note: NoteData) {
+        if let document = inboxDocuments.first(where: { $0.entity.id == note.id })
+            ?? archivedDocuments.first(where: { $0.entity.id == note.id }) {
+            document.entity = note.entity
+            updateDocumentInArray(document)
+        } else {
+            let document = NoteDocument(fileURL: note.fileURL, entity: note.entity)
+            if note.isArchived {
+                archivedCachedUrls.append(note.fileURL)
+                archivedDocuments.append(document)
+            } else {
+                inboxCachedUrls.append(note.fileURL)
+                inboxDocuments.append(document)
+            }
+        }
+    }
+
     // MARK: - Private helpers
 
     private func updateDocumentInArray(_ document: NoteDocument) {

--- a/PiecesOfPaper/Store/TagStore.swift
+++ b/PiecesOfPaper/Store/TagStore.swift
@@ -41,12 +41,12 @@ final class TagStore {
         }
     }
 
-    func tagsFor(document: NoteDocument) -> [TagEntity] {
-        tags.filter { document.entity.tags.contains($0) }
+    func tagsFor(note: NoteData) -> [TagEntity] {
+        tags.filter { note.entity.tags.contains($0) }
     }
 
-    func tagsNotFor(document: NoteDocument) -> [TagEntity] {
-        tags.filter { !document.entity.tags.contains($0) }
+    func tagsNotFor(note: NoteData) -> [TagEntity] {
+        tags.filter { !note.entity.tags.contains($0) }
     }
 
     func filteringTags(from filterBy: [TagEntity]) -> [TagEntity] {

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -44,9 +44,9 @@ struct CanvasView: View {
     private func canvas(windowSize: CGSize) -> some View {
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
-                            saveAction: canvasViewModel.save)
+                            saveAction: { canvasViewModel.save(drawing: $0) })
         .onAppear {
-            canvasView.drawing = canvasViewModel.document.entity.drawing
+            canvasView.drawing = canvasViewModel.note.entity.drawing
             initialContentSize(windowSize: windowSize)
             hideExceptPaper = true
         }
@@ -64,8 +64,7 @@ struct CanvasView: View {
                content: { activityViewController })
         .alert("", isPresented: $showUnsavedAlert) {
             Button {
-                canvasViewModel.document.entity.drawing = canvasView.drawing
-                canvasViewModel.save { success in
+                canvasViewModel.save(drawing: canvasView.drawing) { success in
                     if success {
                         closeCanvas()
                     }
@@ -125,7 +124,7 @@ struct CanvasView: View {
             }
             .accessibilityLabel("Note Information")
             .popover(isPresented: $canvasViewModel.showDrawingInformation) {
-                NoteInformationView(document: canvasViewModel.document)
+                NoteInformationView(note: canvasViewModel.note)
             }
             Button {
                 setToolPickerVisible(false)
@@ -144,8 +143,8 @@ struct CanvasView: View {
         var image = UIImage()
         let trait = UITraitCollection(userInterfaceStyle: .light)
         trait.performAsCurrent {
-            image = canvasViewModel.document.entity.drawing.image(
-                from: canvasViewModel.document.entity.drawing.bounds,
+            image = canvasViewModel.note.entity.drawing.image(
+                from: canvasViewModel.note.entity.drawing.bounds,
                 scale: displayScale
             )
         }
@@ -154,7 +153,7 @@ struct CanvasView: View {
     }
 
     private func done() {
-        if canvasView.drawing != canvasViewModel.document.entity.drawing {
+        if canvasViewModel.hasUnsavedChanges(comparedTo: canvasView.drawing) {
             setToolPickerVisible(false)
             showUnsavedAlert = true
             return
@@ -180,5 +179,5 @@ struct CanvasView: View {
 }
 
 #Preview {
-    CanvasView(canvasViewModel: CanvasViewModel(noteDocument: NoteDocument.createTestData()))
+    CanvasView(canvasViewModel: CanvasViewModel(note: NoteData.createTestData()))
 }

--- a/PiecesOfPaper/View/Canvas/NoteInformationView.swift
+++ b/PiecesOfPaper/View/Canvas/NoteInformationView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct NoteInformationView: View {
-    private(set) var document: NoteDocument
+    private(set) var note: NoteData
     let dataFormatter: DateFormatter = {
         let dataFormatter = DateFormatter()
         dataFormatter.dateStyle = .medium
@@ -52,26 +52,26 @@ struct NoteInformationView: View {
         VStack {
             Group {
                 #if DEBUG
-                Text("🛠" + document.entity.id.uuidString)
+                Text("🛠" + note.entity.id.uuidString)
                     .minimumScaleFactor(0.5)
                 Divider()
                 #endif
             }
             Group {
-                Text(document.fileURL.lastPathComponent)
+                Text(note.fileURL.lastPathComponent)
                     .minimumScaleFactor(0.5)
                 Divider()
-                Text(dataFormatter.string(from: document.entity.createdDate))
+                Text(dataFormatter.string(from: note.entity.createdDate))
                 Divider()
-                Text(dataFormatter.string(from: document.entity.updatedDate))
+                Text(dataFormatter.string(from: note.entity.updatedDate))
                 Divider()
-                Text(document.isArchived ? "Archived" : "Inbox")
+                Text(note.isArchived ? "Archived" : "Inbox")
                 Divider()
-                if document.entity.tags.isEmpty {
+                if note.entity.tags.isEmpty {
                     Text("No tag")
                 } else {
                     ScrollView(.horizontal) {
-                        TagHStack(tags: document.entity.tags)
+                        TagHStack(tags: note.entity.tags)
                     }
                 }
             }
@@ -81,5 +81,5 @@ struct NoteInformationView: View {
 }
 
 #Preview {
-    NoteInformationView(document: NoteDocument.createTestData())
+    NoteInformationView(note: NoteData.createTestData())
 }

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -27,7 +27,7 @@ struct NoteListParentView: View {
             if noteStore.isLoading {
                 ProgressView()
             } else {
-                if noteStore.displayDocuments(for: directory).isEmpty {
+                if noteStore.displayNotes(for: directory).isEmpty {
                     Text("No Data")
                         .font(.largeTitle)
                 } else {
@@ -70,16 +70,16 @@ struct NoteListParentView: View {
                 )
             }
         }
-        .sheet(item: $noteStore.documentToShare) { document in
-            activityViewController(document: document)
+        .sheet(item: $noteStore.noteToShare) { note in
+            activityViewController(note: note)
         }
-        .sheet(item: $noteStore.documentToTag,
+        .sheet(item: $noteStore.noteToTag,
                onDismiss: {
                    Task {
                        await noteStore.incrementalFetch(directory: directory)
                    }
-               }, content: { document in
-            AddTagView(document: document)
+               }, content: { note in
+            AddTagView(note: note)
         })
         .alert("",
                isPresented: $noteStore.showAlert,
@@ -99,7 +99,7 @@ struct NoteListParentView: View {
                     return Text("The app could not access your iCloud Drive. You should change setting")
                 case .archive:
                     let operationText = isTargetDirectoryArchived ? "unarchived" : "archived"
-                    let countText = noteStore.displayDocuments(for: directory).count
+                    let countText = noteStore.displayNotes(for: directory).count
                     let alertText = """
                         Are you sure you want to \(operationText) \(countText) notes?
                     """
@@ -199,9 +199,9 @@ struct NoteListParentView: View {
         }
 
         func scrollToBottom(proxy: ScrollViewProxy) {
-            guard let lastDocument = noteStore.displayDocuments(for: directory).last else { return }
+            guard let lastNote = noteStore.displayNotes(for: directory).last else { return }
             withAnimation {
-                proxy.scrollTo(lastDocument.id, anchor: .bottom)
+                proxy.scrollTo(lastNote.id, anchor: .bottom)
             }
         }
     }
@@ -212,8 +212,8 @@ struct NoteListParentView: View {
         return canvasViewModel
     }
 
-    private func activityViewController(document: NoteDocument) -> UIActivityViewControllerWrapper {
-        let drawing = document.entity.drawing
+    private func activityViewController(note: NoteData) -> UIActivityViewControllerWrapper {
+        let drawing = note.entity.drawing
         var image = UIImage()
         let trait = UITraitCollection(userInterfaceStyle: .light)
         trait.performAsCurrent {

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -55,7 +55,7 @@ struct NoteListParentView: View {
         .fullScreenCover(isPresented: $noteStore.showCanvasView) {
             if let path = FilePath.inboxUrl?.appendingPathComponent(FilePath.fileName) {
                 NavigationStack {
-                    CanvasView(canvasViewModel: CanvasViewModel(path: path))
+                    CanvasView(canvasViewModel: makeNewNoteCanvasViewModel(path: path))
                 }
             }
         }
@@ -204,6 +204,12 @@ struct NoteListParentView: View {
                 proxy.scrollTo(lastDocument.id, anchor: .bottom)
             }
         }
+    }
+
+    private func makeNewNoteCanvasViewModel(path: URL) -> CanvasViewModel {
+        let canvasViewModel = CanvasViewModel(newNoteAt: path)
+        canvasViewModel.onPersisted = { noteStore.upsert($0) }
+        return canvasViewModel
     }
 
     private func activityViewController(document: NoteDocument) -> UIActivityViewControllerWrapper {

--- a/PiecesOfPaper/View/NoteList/NoteListView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListView.swift
@@ -16,57 +16,57 @@ struct NoteListView: View {
 
     var body: some View {
         LazyVGrid(columns: [gridItem]) {
-            ForEach(noteStore.displayDocuments(for: directory)) { document in
+            ForEach(noteStore.displayNotes(for: directory)) { note in
                 VStack {
-                    NoteView(document: document)
+                    NoteView(note: note)
                     .contextMenu {
-                        contextMenu(document: document)
+                        contextMenu(note: note)
                     }
                     NoteListTagHStack(
-                        tags: tagStore.tagsFor(document: document),
+                        tags: tagStore.tagsFor(note: note),
                         action: {
-                            noteStore.documentToTag = document
+                            noteStore.noteToTag = note
                         }
                     )
                         .padding(.horizontal)
                 }
-                .id(document.id)
+                .id(note.id)
             }
         }
     }
 
-    func contextMenu(document: NoteDocument) -> some View {
+    func contextMenu(note: NoteData) -> some View {
         Group {
             Button {
-                noteStore.duplicate(document, in: directory)
+                noteStore.duplicate(note, in: directory)
             } label: {
                 Label("Duplicate", systemImage: "doc.on.doc")
             }
-            if document.isArchived {
+            if note.isArchived {
                 Button {
-                    noteStore.unarchive(document)
+                    noteStore.unarchive(note)
                 } label: {
                     Label("Move to Inbox", systemImage: "tray")
                 }
                 Button(role: .destructive) {
-                    noteStore.delete(document)
+                    noteStore.delete(note)
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
             } else {
                 Button {
-                    noteStore.archive(document)
+                    noteStore.archive(note)
                 } label: {
                     Label("Move to Trash", systemImage: "trash")
                 }
             }
             Button {
-                noteStore.documentToShare = document
+                noteStore.noteToShare = note
             } label: {
                 Label("Share", systemImage: "square.and.arrow.up")
             }
             Button {
-                noteStore.documentToTag = document
+                noteStore.noteToTag = note
             } label: {
                 Label("Tag", systemImage: "tag")
             }

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -11,6 +11,7 @@ import PencilKit
 
 struct NoteView: View {
     private(set) var document: NoteDocument
+    @Environment(NoteStore.self) private var noteStore
     @State private var showCanvasView = false
     @State private var thumbnail: UIImage?
 
@@ -37,9 +38,15 @@ struct NoteView: View {
         }
         .fullScreenCover(isPresented: $showCanvasView) {
             NavigationView {
-                CanvasView(canvasViewModel: CanvasViewModel(noteDocument: document))
+                CanvasView(canvasViewModel: makeCanvasViewModel())
             }
         }
+    }
+
+    private func makeCanvasViewModel() -> CanvasViewModel {
+        let canvasViewModel = CanvasViewModel(note: document.noteData)
+        canvasViewModel.onPersisted = { noteStore.upsert($0) }
+        return canvasViewModel
     }
 }
 

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import PencilKit
 
 struct NoteView: View {
-    private(set) var document: NoteDocument
+    private(set) var note: NoteData
     @Environment(NoteStore.self) private var noteStore
     @State private var showCanvasView = false
     @State private var thumbnail: UIImage?
@@ -33,8 +33,8 @@ struct NoteView: View {
             .shadow(radius: 5)
         })
         .accessibilityLabel("Note")
-        .task(id: document.entity.updatedDate) {
-            thumbnail = await ThumbnailCache.shared.thumbnail(for: document)
+        .task(id: note.entity.updatedDate) {
+            thumbnail = await ThumbnailCache.shared.thumbnail(for: note)
         }
         .fullScreenCover(isPresented: $showCanvasView) {
             NavigationView {
@@ -44,12 +44,13 @@ struct NoteView: View {
     }
 
     private func makeCanvasViewModel() -> CanvasViewModel {
-        let canvasViewModel = CanvasViewModel(note: document.noteData)
+        let canvasViewModel = CanvasViewModel(note: note)
         canvasViewModel.onPersisted = { noteStore.upsert($0) }
         return canvasViewModel
     }
 }
 
 #Preview {
-    NoteView(document: NoteDocument.createTestData())
+    NoteView(note: NoteData.createTestData())
+        .environment(NoteStore())
 }

--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -15,13 +15,13 @@ final class ThumbnailCache {
     static let shared = ThumbnailCache()
     private let cache = NSCache<NSString, UIImage>()
 
-    func thumbnail(for document: NoteDocument) async -> UIImage {
-        let key = "\(document.entity.id.uuidString)-\(document.entity.updatedDate.timeIntervalSince1970)" as NSString
+    func thumbnail(for note: NoteData) async -> UIImage {
+        let key = "\(note.entity.id.uuidString)-\(note.entity.updatedDate.timeIntervalSince1970)" as NSString
         if let cached = cache.object(forKey: key) {
             return cached
         }
 
-        let drawing = document.entity.drawing
+        let drawing = note.entity.drawing
         guard !drawing.bounds.isNull else { return UIImage() }
 
         let image = await Task.detached(priority: .userInitiated) {

--- a/PiecesOfPaper/View/Tag/AddTagView.swift
+++ b/PiecesOfPaper/View/Tag/AddTagView.swift
@@ -9,11 +9,22 @@
 import SwiftUI
 
 struct AddTagView: View {
-    private(set) var document: NoteDocument
+    // Snapshot from sheet(item:); read the latest state through the store by id
+    let note: NoteData
     @Environment(NoteStore.self) private var noteStore
     @Environment(TagStore.self) private var tagStore
-    @State private var tagsToNote: [TagEntity] = []
-    @State private var tagsNotToNote: [TagEntity] = []
+
+    private var currentNote: NoteData {
+        noteStore.note(id: note.id) ?? note
+    }
+
+    private var tagsToNote: [TagEntity] {
+        tagStore.tagsFor(note: currentNote)
+    }
+
+    private var tagsNotToNote: [TagEntity] {
+        tagStore.tagsNotFor(note: currentNote)
+    }
 
     var body: some View {
         List {
@@ -33,28 +44,20 @@ struct AddTagView: View {
         }
         .onAppear {
             tagStore.reload()
-            updateFilteredTags()
         }
     }
 
-    private func updateFilteredTags() {
-        tagsToNote = tagStore.tagsFor(document: document)
-        tagsNotToNote = tagStore.tagsNotFor(document: document)
-    }
-
     private func add(_ tag: TagEntity) {
-        noteStore.addTag(tag, to: document)
-        updateFilteredTags()
+        noteStore.addTag(tag, to: currentNote)
     }
 
     private func remove(_ tag: TagEntity) {
-        noteStore.removeTag(tag, from: document)
-        updateFilteredTags()
+        noteStore.removeTag(tag, from: currentNote)
     }
 }
 
 #Preview {
-    AddTagView(document: NoteDocument.createTestData())
+    AddTagView(note: NoteData.createTestData())
         .environment(NoteStore())
         .environment(TagStore())
 }

--- a/PiecesOfPaper/ViewModel/CanvasViewModel.swift
+++ b/PiecesOfPaper/ViewModel/CanvasViewModel.swift
@@ -9,11 +9,13 @@
 import Foundation
 import PencilKit
 
+@MainActor
 @Observable
 final class CanvasViewModel {
-    private(set) var document: NoteDocument
+    private(set) var note: NoteData
     var showDrawingInformation = false
     var showSaveFailedAlert = false
+    var onPersisted: ((NoteData) -> Void)?
     private let noteRepository: NoteRepositoryProtocol
 
     var canReviewRequest: Bool {
@@ -24,29 +26,35 @@ final class CanvasViewModel {
         return inboxFileNames.count >= 5
     }
 
-    init(path: URL, noteRepository: NoteRepositoryProtocol = NoteRepository()) {
-        self.document = NoteDocument(fileURL: path, entity: NoteEntity(drawing: PKDrawing()))
+    init(newNoteAt path: URL, noteRepository: NoteRepositoryProtocol = NoteRepository()) {
+        self.note = NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: path)
         self.noteRepository = noteRepository
     }
 
-    init(noteDocument: NoteDocument, noteRepository: NoteRepositoryProtocol = NoteRepository()) {
-        self.document = noteDocument
+    init(note: NoteData, noteRepository: NoteRepositoryProtocol = NoteRepository()) {
+        self.note = note
         self.noteRepository = noteRepository
     }
 
-    func save(completion: ((Bool) -> Void)? = nil) {
-        document.entity.updatedDate = Date()
-        noteRepository.save(document: document) { [weak self] success in
-            if !success {
+    func hasUnsavedChanges(comparedTo drawing: PKDrawing) -> Bool {
+        drawing != note.entity.drawing
+    }
+
+    func save(drawing: PKDrawing, completion: ((Bool) -> Void)? = nil) {
+        guard hasUnsavedChanges(comparedTo: drawing) else {
+            completion?(true)
+            return
+        }
+        note.entity.drawing = drawing
+        note.entity.updatedDate = Date()
+        let saved = note
+        noteRepository.save(saved.entity, to: saved.fileURL) { [weak self] success in
+            if success {
+                self?.onPersisted?(saved)
+            } else {
                 self?.showSaveFailedAlert = true
             }
             completion?(success)
         }
-    }
-
-    func save(drawing: PKDrawing) {
-        guard document.entity.drawing != drawing else { return }
-        document.entity.drawing = drawing
-        save()
     }
 }

--- a/PiecesOfPaperTests/CanvasViewModelTests.swift
+++ b/PiecesOfPaperTests/CanvasViewModelTests.swift
@@ -1,0 +1,87 @@
+//
+//  CanvasViewModelTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/18.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import UIKit
+import Testing
+import PencilKit
+@testable import Pieces_of_Paper
+
+@MainActor
+struct CanvasViewModelTests {
+    let repositoryMock = NoteRepositoryMock(documents: [])
+    let viewModel: CanvasViewModel
+
+    init() {
+        viewModel = CanvasViewModel(note: NoteData.createTestData(), noteRepository: repositoryMock)
+    }
+
+    private func makeDrawing() -> PKDrawing {
+        let point = PKStrokePoint(location: .zero,
+                                  timeOffset: 0,
+                                  size: CGSize(width: 1, height: 1),
+                                  opacity: 1,
+                                  force: 1,
+                                  azimuth: 0,
+                                  altitude: 0)
+        let path = PKStrokePath(controlPoints: [point], creationDate: Date())
+        return PKDrawing(strokes: [PKStroke(ink: PKInk(.pen, color: .black), path: path)])
+    }
+
+    @Test func hasUnsavedChanges_detectsDrawingDifference() {
+        #expect(!viewModel.hasUnsavedChanges(comparedTo: viewModel.note.entity.drawing))
+        #expect(viewModel.hasUnsavedChanges(comparedTo: makeDrawing()))
+    }
+
+    @Test func save_skipsWhenDrawingUnchanged() {
+        var persisted: NoteData?
+        viewModel.onPersisted = { persisted = $0 }
+        let originalUpdatedDate = viewModel.note.entity.updatedDate
+
+        var completionResult: Bool?
+        viewModel.save(drawing: viewModel.note.entity.drawing) { completionResult = $0 }
+
+        #expect(completionResult == true)
+        #expect(persisted == nil)
+        #expect(viewModel.note.entity.updatedDate == originalUpdatedDate)
+    }
+
+    @Test func save_updatesDrawingAndDateOnSuccess() {
+        let drawing = makeDrawing()
+        let originalUpdatedDate = viewModel.note.entity.updatedDate
+
+        viewModel.save(drawing: drawing)
+
+        #expect(viewModel.note.entity.drawing == drawing)
+        #expect(viewModel.note.entity.updatedDate > originalUpdatedDate)
+        #expect(!viewModel.showSaveFailedAlert)
+    }
+
+    @Test func save_notifiesPersistedNoteOnSuccess() {
+        var persisted: NoteData?
+        viewModel.onPersisted = { persisted = $0 }
+        let drawing = makeDrawing()
+
+        viewModel.save(drawing: drawing)
+
+        #expect(persisted == viewModel.note)
+        #expect(persisted?.entity.drawing == drawing)
+    }
+
+    @Test func save_flagsAlertAndSkipsCallbackOnFailure() {
+        repositoryMock.saveShouldSucceed = false
+        var persisted: NoteData?
+        viewModel.onPersisted = { persisted = $0 }
+
+        var completionResult: Bool?
+        viewModel.save(drawing: makeDrawing()) { completionResult = $0 }
+
+        #expect(completionResult == false)
+        #expect(persisted == nil)
+        #expect(viewModel.showSaveFailedAlert)
+    }
+}

--- a/PiecesOfPaperTests/CanvasViewModelTests.swift
+++ b/PiecesOfPaperTests/CanvasViewModelTests.swift
@@ -13,7 +13,7 @@ import PencilKit
 
 @MainActor
 struct CanvasViewModelTests {
-    let repositoryMock = NoteRepositoryMock(documents: [])
+    let repositoryMock = NoteRepositoryMock(notes: [])
     let viewModel: CanvasViewModel
 
     init() {

--- a/PiecesOfPaperTests/NoteDataTests.swift
+++ b/PiecesOfPaperTests/NoteDataTests.swift
@@ -1,0 +1,41 @@
+//
+//  NoteDataTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/18.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+import Testing
+import PencilKit
+@testable import Pieces_of_Paper
+
+struct NoteDataTests {
+    @Test func id_delegatesToEntityId() {
+        let note = NoteData.createTestData()
+        #expect(note.id == note.entity.id)
+    }
+
+    @Test func isArchived_trueForFileUnderArchivedDirectory() throws {
+        let archivedUrl = try #require(FilePath.archivedUrl)
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: archivedUrl.appendingPathComponent("test.plist"))
+        #expect(note.isArchived)
+    }
+
+    @Test func isArchived_falseForFileOutsideArchivedDirectory() throws {
+        let inboxUrl = try #require(FilePath.inboxUrl)
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: inboxUrl.appendingPathComponent("test.plist"))
+        #expect(!note.isArchived)
+    }
+
+    @Test func equatable_detectsEntityChange() {
+        let note = NoteData.createTestData()
+        var modified = note
+        #expect(note == modified)
+        modified.entity.tags.append(TagEntity(name: "tag", color: CodableUIColor(uiColor: .red)))
+        #expect(note != modified)
+    }
+}

--- a/PiecesOfPaperTests/NoteDocumentTests.swift
+++ b/PiecesOfPaperTests/NoteDocumentTests.swift
@@ -8,27 +8,36 @@
 
 import Foundation
 import Testing
+import PencilKit
 @testable import Pieces_of_Paper
 
 @MainActor
 struct NoteDocumentTests {
+    private func makeDocument() -> NoteDocument {
+        guard let url = URL(string: "file:///test") else {
+            fatalError()
+        }
+
+        return NoteDocument(fileURL: url, entity: NoteEntity(drawing: PKDrawing()))
+    }
+
     @Test func contents_encodesEntity() throws {
-        let document = NoteDocument.createTestData()
+        let document = makeDocument()
         let data = try #require(try document.contents(forType: "") as? Data)
         let decoded = try PropertyListDecoder().decode(NoteEntity.self, from: data)
         #expect(decoded.id == document.entity.id)
     }
 
     @Test func load_roundTripsEntity() throws {
-        let document = NoteDocument.createTestData()
+        let document = makeDocument()
         let data = try #require(try document.contents(forType: "") as? Data)
-        let other = NoteDocument.createTestData()
+        let other = makeDocument()
         try other.load(fromContents: data, ofType: nil)
         #expect(other.entity.id == document.entity.id)
     }
 
     @Test func load_throwsOnGarbageData() {
-        let document = NoteDocument.createTestData()
+        let document = makeDocument()
         let originalId = document.entity.id
         #expect(throws: (any Error).self) {
             try document.load(fromContents: Data("not a plist".utf8), ofType: nil)
@@ -37,7 +46,7 @@ struct NoteDocumentTests {
     }
 
     @Test func load_throwsOnNonDataContents() {
-        let document = NoteDocument.createTestData()
+        let document = makeDocument()
         #expect(throws: NoteDocumentError.self) {
             try document.load(fromContents: NSObject(), ofType: nil)
         }

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -14,10 +14,10 @@ import Testing
 struct NoteStoreTests {
     var noteStore: NoteStore
     let repositoryMock: NoteRepositoryMock
-    let documents = (0...2).map { _ in NoteDocument.createTestData() }
+    let notes = (0...2).map { _ in NoteData.createTestData() }
 
     init() {
-        repositoryMock = NoteRepositoryMock(documents: documents)
+        repositoryMock = NoteRepositoryMock(notes: notes)
         noteStore = NoteStore(
             noteRepository: repositoryMock,
             preferenceRepository: PreferenceRepositoryMock()
@@ -26,7 +26,7 @@ struct NoteStoreTests {
 
     @Test func test_incrementalFetch() async throws {
         await noteStore.incrementalFetch(directory: .inbox)
-        #expect(noteStore.displayInboxDocuments == documents.reversed())
+        #expect(noteStore.displayInboxDocuments.map(\.noteData) == notes.reversed())
     }
 
     @Test func test_incrementalFetch_skipsUnreadableFileAndShowsError() async {
@@ -93,12 +93,12 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         // swiftlint:enable force_unwrapping
     }
 
-    var documents: [NoteDocument]
+    var notes: [NoteData]
     var failingUrls: Set<URL> = []
     var moveShouldThrow = false
 
-    init(documents: [NoteDocument]) {
-        self.documents = documents
+    init(notes: [NoteData]) {
+        self.notes = notes
     }
 
     func getFileUrls(directory: NoteDirectory) -> [URL] {
@@ -106,27 +106,23 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     }
 
     @MainActor
-    func open(fileUrl: URL) async throws -> NoteDocument {
+    func open(fileUrl: URL) async throws -> NoteData {
         if failingUrls.contains(fileUrl) {
             throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)
         }
         switch fileUrl.lastPathComponent {
         case "file1":
-            return documents[0]
+            return notes[0]
         case "file2":
-            return documents[1]
+            return notes[1]
         case "file3":
-            return documents[2]
+            return notes[2]
         default:
             fatalError()
         }
     }
 
     var saveShouldSucceed = true
-    func save(document: NoteDocument, completion: @escaping (Bool) -> Void) {
-        completion(saveShouldSucceed)
-    }
-
     func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void) {
         completion(saveShouldSucceed)
     }
@@ -140,8 +136,8 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         return fileUrl
     }
 
-    func duplicate(document: NoteDocument, in directory: NoteDirectory,
-                   completion: @escaping (NoteDocument?) -> Void) {
+    func duplicate(_ note: NoteData, in directory: NoteDirectory,
+                   completion: @escaping (NoteData?) -> Void) {
         completion(nil)
     }
 }

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -127,6 +127,10 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         completion(saveShouldSucceed)
     }
 
+    func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void) {
+        completion(saveShouldSucceed)
+    }
+
     func delete(fileUrl: URL) throws {}
 
     func move(fileUrl: URL, to directory: NoteDirectory) throws -> URL {

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Testing
+import PencilKit
 @testable import Pieces_of_Paper
 
 @MainActor
@@ -72,6 +73,36 @@ struct NoteStoreTests {
         noteStore.addTag(tag, to: target)
         #expect(noteStore.note(id: target.id)?.entity.tags.isEmpty == true)
         #expect(noteStore.showAlert)
+    }
+
+    @Test func test_noteById_looksUpFetchedNote() async {
+        await noteStore.incrementalFetch(directory: .inbox)
+        #expect(noteStore.note(id: notes[1].id) == notes[1])
+        #expect(noteStore.note(id: UUID()) == nil)
+    }
+
+    @Test func test_upsert_replacesExistingNote() async {
+        await noteStore.incrementalFetch(directory: .inbox)
+        var updated = notes[0]
+        updated.entity.updatedDate = Date()
+        noteStore.upsert(updated)
+        #expect(noteStore.note(id: updated.id) == updated)
+        #expect(noteStore.inboxNotes.count == 3)
+    }
+
+    @Test func test_upsert_insertsUnknownNoteIntoInbox() {
+        let note = NoteData.createTestData()
+        noteStore.upsert(note)
+        #expect(noteStore.inboxNotes == [note])
+    }
+
+    @Test func test_upsert_thenIncrementalFetchDoesNotDuplicate() async {
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: NoteRepositoryMock.TestFile.file1.url)
+        noteStore.upsert(note)
+        await noteStore.incrementalFetch(directory: .inbox)
+        #expect(noteStore.inboxNotes.count == 3)
+        #expect(noteStore.inboxNotes.filter { $0.fileURL == NoteRepositoryMock.TestFile.file1.url }.count == 1)
     }
 }
 

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -26,51 +26,51 @@ struct NoteStoreTests {
 
     @Test func test_incrementalFetch() async throws {
         await noteStore.incrementalFetch(directory: .inbox)
-        #expect(noteStore.displayInboxDocuments.map(\.noteData) == notes.reversed())
+        #expect(noteStore.displayInboxNotes == notes.reversed())
     }
 
     @Test func test_incrementalFetch_skipsUnreadableFileAndShowsError() async {
         repositoryMock.failingUrls = [NoteRepositoryMock.TestFile.file2.url]
         await noteStore.incrementalFetch(directory: .inbox)
-        #expect(noteStore.displayInboxDocuments.count == 2)
+        #expect(noteStore.displayInboxNotes.count == 2)
         #expect(noteStore.showAlert)
     }
 
     @Test func test_incrementalFetch_retriesFailedFileOnNextFetch() async {
         repositoryMock.failingUrls = [NoteRepositoryMock.TestFile.file2.url]
         await noteStore.incrementalFetch(directory: .inbox)
-        #expect(noteStore.displayInboxDocuments.count == 2)
+        #expect(noteStore.displayInboxNotes.count == 2)
 
         repositoryMock.failingUrls = []
         await noteStore.incrementalFetch(directory: .inbox)
-        #expect(noteStore.displayInboxDocuments.count == 3)
+        #expect(noteStore.displayInboxNotes.count == 3)
     }
 
-    @Test func test_archive_keepsDocumentWhenMoveFails() async {
+    @Test func test_archive_keepsNoteWhenMoveFails() async {
         await noteStore.incrementalFetch(directory: .inbox)
         repositoryMock.moveShouldThrow = true
-        let target = noteStore.displayInboxDocuments[0]
+        let target = noteStore.displayInboxNotes[0]
         noteStore.archive(target)
-        #expect(noteStore.displayInboxDocuments.count == 3)
-        #expect(noteStore.displayArchivedDocuments.isEmpty)
+        #expect(noteStore.displayInboxNotes.count == 3)
+        #expect(noteStore.displayArchivedNotes.isEmpty)
     }
 
     @Test func test_addTag_persistsTagOnSuccessfulSave() async {
         await noteStore.incrementalFetch(directory: .inbox)
-        let target = noteStore.displayInboxDocuments[0]
+        let target = noteStore.displayInboxNotes[0]
         let tag = TagEntity(name: "test", color: CodableUIColor(uiColor: .red))
         noteStore.addTag(tag, to: target)
-        #expect(target.entity.tags == [tag])
+        #expect(noteStore.note(id: target.id)?.entity.tags == [tag])
         #expect(!noteStore.showAlert)
     }
 
     @Test func test_addTag_rollsBackTagWhenSaveFails() async {
         await noteStore.incrementalFetch(directory: .inbox)
         repositoryMock.saveShouldSucceed = false
-        let target = noteStore.displayInboxDocuments[0]
+        let target = noteStore.displayInboxNotes[0]
         let tag = TagEntity(name: "test", color: CodableUIColor(uiColor: .red))
         noteStore.addTag(tag, to: target)
-        #expect(target.entity.tags.isEmpty)
+        #expect(noteStore.note(id: target.id)?.entity.tags.isEmpty == true)
         #expect(noteStore.showAlert)
     }
 }


### PR DESCRIPTION
Closes #160

## Summary

`NoteDocument` (a `UIDocument` subclass, i.e. a reference type) used to carry both file I/O and view state, and was passed all the way down to SwiftUI views. This PR separates those responsibilities: views and stores now only deal with a new value type `NoteData`, while `NoteDocument` is confined to the internals of `NoteRepository`.

**Diff size**: 19 files, +464 / −224 lines (7 commits, each keeping the test suite green)

## Changes

### ① New `NoteData` value type (Model/NoteData.swift)
- A struct holding `entity: NoteEntity` + `fileURL: URL`. `Identifiable` (id is `entity.id` — the identifier used by ForEach / `sheet(item:)` / `.id()` / `scrollTo` stays the same value as before) and `Equatable` (memberwise; `NoteEntity` also gains `Equatable`)
- `isArchived` moved over from `NoteDocument`

### ② Repository — `NoteDocument` confined to its internals
- `open` now returns `NoteData`; `save(_ entity:to:)` / `duplicate(_ note:in:)` are value-based. Saving still creates a transient `NoteDocument` and calls `UIDocument.save(to:for:)` as before (the completion handler keeps the instance alive, so the iCloud conflict-resolution observer stays active during the save, same as today)

### ③ NoteStore — the source of truth becomes `[NoteData]`
- Replaced with `inboxNotes/archivedNotes`, `displayNotes(for:)`, `noteToShare/noteToTag`. archive/unarchive no longer re-creates `NoteDocument` instances; it just rebuilds a `NoteData` with the new URL
- addTag/removeTag now do value-based optimistic updates with rollback on failure (the old trick of re-assigning the same reference to trigger observation is gone)
- New `note(id:)` (lookup of the latest state) and `upsert(_:)` (write-back entry point for canvas saves; for new notes it also updates cachedUrls so the post-dismiss `incrementalFetch` does not add a duplicate)

### ④ Canvas write path reworked [behavior-affecting]
- `CanvasView` no longer mutates `document.entity.drawing` directly. Diffing goes through `hasUnsavedChanges(comparedTo:)` and saving is unified into `save(drawing:completion:)`
- `CanvasViewModel` is `@MainActor` and holds a `NoteData`. On a successful save it reports back via the `onPersisted` callback, which feeds `NoteStore.upsert`
- **List refresh after canvas edits used to depend implicitly on the view model and the store sharing the same reference**; it is now an explicit write-back path, so thumbnail and sort-order updates after a save are structurally guaranteed

### ⑤ View layer swap (mechanical, except AddTagView) [AddTagView is behavior-affecting]
- `NoteListView` / `NoteView` / `NoteListParentView` / `NoteInformationView` / `ThumbnailCache` / `TagStore.tagsFor` — mechanical replacement with `NoteData` (`.id(note.id)` keeps the same UUID, so the #165 scroll fix is untouched)
- `AddTagView` — with a value snapshot from `sheet(item:)`, tag additions/removals would no longer show up on screen, so it was redesigned to read the latest state via `noteStore.note(id:)`. The two hand-managed `@State` arrays and `updateFilteredTags()` are removed in favor of @Observable re-evaluation

### ⑥ NoteDocument slimmed down
- Dropped `Identifiable`, `isArchived`, and `createTestData()`. Its remaining responsibilities are plist encoding/decoding and iCloud conflict resolution. The only remaining references are the repository and its own tests

### ⑦ Tests
- New: `NoteDataTests` (4), `CanvasViewModelTests` (5: skip when unchanged / updatedDate refresh / onPersisted firing / alert + no callback on failure / hasUnsavedChanges), plus 4 new `NoteStoreTests` for upsert, `note(id:)`, and duplicate prevention
- Existing tests follow the new APIs (the addTag tests now assert the store's state directly instead of a shared reference)
- All tests pass

## Deviations from the issue

- The "dual arrays" (`noteDocuments` / `displayNoteDocuments`) called out in the issue had already been resolved, so they are out of scope here
- This PR goes one step further than the issue's proposal (keeping `[NoteDocument]` inside the store): the store's source of truth is also `[NoteData]`. Since `NoteRepository.open` opens and closes the document before returning, a `NoteDocument` held by the store was effectively just a carrier of entity + fileURL, so there was no value in keeping it around

## Verification

- `xcodebuild test` green on every commit (iPhone SE 3rd gen / iOS 18.3.1)
- Launch smoke test on the simulator: note list renders, the new-note canvas opens with iCloud disabled, and the process stays alive. Tap injection is not available in this environment, so interactive flows (tag sheet, archive, etc.) were not exercised — recommended manual checks on a device: (1) edit an existing note, close it, and confirm the list thumbnail and sort order update; (2) add/remove tags in the tag sheet and confirm they appear immediately (the behavior-affecting changes in ④ and ⑤)
