### PR TITLE
Add CLAUDE.md documenting the English-language convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+## Language
+
+- All GitHub-facing text is written in English: PR titles/bodies, issue titles/bodies, commit messages, and code comments.
+- Conversation with the user may be in Japanese; the repository's written artifacts stay in English.


### PR DESCRIPTION
Closes #180

Adds a root CLAUDE.md documenting that all GitHub-facing text (PR titles/bodies, issue titles/bodies, commit messages, code comments) is written in English, while conversation with the user may be in Japanese.

Documentation only — no code changes.