### PR TITLE
Fix device-only canvas breakage: GeometryReader wrapping and off-main thumbnail rendering

### DIFF
--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -21,6 +21,9 @@ struct CanvasView: View {
     @State private var hideExceptPaper = true
     @State private var isShowActivityView = false
     @State private var showUnsavedAlert = false
+    @State private var windowSize = CGSize.zero
+    @State private var isDrawingLoaded = false
+    @State private var hasAppliedInitialContentSize = false
 
     private var tapGesture: some Gesture {
         TapGesture(count: 1)
@@ -36,18 +39,25 @@ struct CanvasView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            canvas(windowSize: geometry.size)
-        }
+        // Not a GeometryReader: wrapping the canvas in one breaks Apple Pencil
+        // input and stroke rendering on device (#187).
+        canvas
+            .onGeometryChange(for: CGSize.self) { proxy in
+                proxy.size
+            } action: { size in
+                windowSize = size
+                applyInitialContentSizeIfNeeded()
+            }
     }
 
-    private func canvas(windowSize: CGSize) -> some View {
+    private var canvas: some View {
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
                             saveAction: { canvasViewModel.save(drawing: $0) })
         .onAppear {
             canvasView.drawing = canvasViewModel.note.entity.drawing
-            initialContentSize(windowSize: windowSize)
+            isDrawingLoaded = true
+            applyInitialContentSizeIfNeeded()
             hideExceptPaper = true
         }
         .gesture(tapGesture)
@@ -96,6 +106,12 @@ struct CanvasView: View {
 
     private func isDrawingHigher(than windowSize: CGSize) -> Bool {
         windowSize.height < canvasView.drawing.bounds.maxY
+    }
+
+    private func applyInitialContentSizeIfNeeded() {
+        guard isDrawingLoaded, windowSize != .zero, !hasAppliedInitialContentSize else { return }
+        hasAppliedInitialContentSize = true
+        initialContentSize(windowSize: windowSize)
     }
 
     private func initialContentSize(windowSize: CGSize) {

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -14,16 +14,12 @@ import LinkPresentation
 struct CanvasView: View {
     @State var canvasViewModel: CanvasViewModel
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.displayScale) private var displayScale
     @AppStorage("review_requested") private var reviewRequested = false
     @State private var canvasView = PKCanvasView()
     @State private var toolPicker = PKToolPicker()
     @State private var hideExceptPaper = true
     @State private var isShowActivityView = false
     @State private var showUnsavedAlert = false
-    @State private var windowSize = CGSize.zero
-    @State private var isDrawingLoaded = false
-    @State private var hasAppliedInitialContentSize = false
 
     private var tapGesture: some Gesture {
         TapGesture(count: 1)
@@ -39,25 +35,14 @@ struct CanvasView: View {
     }
 
     var body: some View {
-        // Not a GeometryReader: wrapping the canvas in one breaks Apple Pencil
-        // input and stroke rendering on device (#187).
-        canvas
-            .onGeometryChange(for: CGSize.self) { proxy in
-                proxy.size
-            } action: { size in
-                windowSize = size
-                applyInitialContentSizeIfNeeded()
-            }
-    }
-
-    private var canvas: some View {
+        // No GeometryReader or geometry observation here: wrapping the canvas in
+        // size-reading machinery breaks Apple Pencil input on device (#187).
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
                             saveAction: { canvasViewModel.save(drawing: $0) })
         .onAppear {
             canvasView.drawing = canvasViewModel.note.entity.drawing
-            isDrawingLoaded = true
-            applyInitialContentSizeIfNeeded()
+            initialContentSize(windowSize: screenSize)
             hideExceptPaper = true
         }
         .gesture(tapGesture)
@@ -100,18 +85,20 @@ struct CanvasView: View {
 
     // MARK: - Window Adjustment
 
+    private var windowScene: UIWindowScene? {
+        UIApplication.shared.connectedScenes.first as? UIWindowScene
+    }
+
+    private var screenSize: CGSize {
+        windowScene?.screen.bounds.size ?? .zero
+    }
+
     private func isDrawingWider(than windowSize: CGSize) -> Bool {
         windowSize.width < canvasView.drawing.bounds.maxX
     }
 
     private func isDrawingHigher(than windowSize: CGSize) -> Bool {
         windowSize.height < canvasView.drawing.bounds.maxY
-    }
-
-    private func applyInitialContentSizeIfNeeded() {
-        guard isDrawingLoaded, windowSize != .zero, !hasAppliedInitialContentSize else { return }
-        hasAppliedInitialContentSize = true
-        initialContentSize(windowSize: windowSize)
     }
 
     private func initialContentSize(windowSize: CGSize) {
@@ -161,7 +148,7 @@ struct CanvasView: View {
         trait.performAsCurrent {
             image = canvasViewModel.note.entity.drawing.image(
                 from: canvasViewModel.note.entity.drawing.bounds,
-                scale: displayScale
+                scale: windowScene?.screen.scale ?? 2.0
             )
         }
 

--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PencilKit
 
-/// Renders note thumbnails off the main thread and caches them.
+/// Renders note thumbnails asynchronously and caches them.
 /// The cache key includes updatedDate, so an edited note is re-rendered automatically.
 final class ThumbnailCache {
     static let shared = ThumbnailCache()
@@ -24,9 +24,11 @@ final class ThumbnailCache {
         let drawing = note.entity.drawing
         guard !drawing.bounds.isNull else { return UIImage() }
 
-        let image = await Task.detached(priority: .userInitiated) {
+        // Not Task.detached: rendering PKDrawing off the main thread breaks
+        // PKCanvasView drawing process-wide on device (#187).
+        let image = await MainActor.run {
             drawing.image(from: drawing.bounds, scale: 1.0)
-        }.value
+        }
         cache.setObject(image, forKey: key)
         return image
     }


### PR DESCRIPTION
Closes #187

## Problem

Since the July changes, the canvas is completely broken on a real iPad: Apple Pencil strokes are not drawn, and opening an existing note shows a blank canvas. The bug does not reproduce in the Simulator or in unit tests. An on-device bisect (details in #187) identified **two independent regressions**, either of which alone keeps the canvas broken:

1. `ed948fc` (#172) wrapped `CanvasView`'s body in a `GeometryReader` to obtain the window size — with the wrapper in place, Pencil strokes stop drawing on device.
2. `ad08d59` (#174) renders thumbnails via `PKDrawing.image(from:scale:)` inside `Task.detached` — PencilKit keeps process-wide renderer state, and one off-main render permanently breaks `PKCanvasView` stroke drawing on device.

## Fix

- **CanvasView**: remove the `GeometryReader` (and the `displayScale` environment read) and take the window size for `initialContentSize` from `UIWindowScene.screen`. The deprecated `UIScreen.main` (the original motivation for #172) stays removed. The view structure is back to the last known-good shape (`be04bf6`).
- **ThumbnailCache**: render inside `MainActor.run` instead of `Task.detached`. The render is still deferred out of view-body evaluation and cached (preserving the intent of #173/#174), but the actual PencilKit call happens on the main thread.

## Verification

- On-device (iPad, Apple Pencil): with both fixes applied on top of `#174`, drawing works again; with either fix missing, it does not. Verified through the diag builds documented in #187.
- Full unit test suite passes (38 tests); Simulator build clean.
- Final on-device check of this exact branch (on `main`) is recommended before merge.
