### PR TITLE
Render note thumbnails on the main actor to fix broken Pencil drawing on device

### DIFF
--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PencilKit
 
-/// Renders note thumbnails off the main thread and caches them.
+/// Renders note thumbnails asynchronously and caches them.
 /// The cache key includes updatedDate, so an edited note is re-rendered automatically.
 final class ThumbnailCache {
     static let shared = ThumbnailCache()
@@ -24,9 +24,11 @@ final class ThumbnailCache {
         let drawing = note.entity.drawing
         guard !drawing.bounds.isNull else { return UIImage() }
 
-        let image = await Task.detached(priority: .userInitiated) {
+        // Not Task.detached: rendering PKDrawing off the main thread breaks
+        // PKCanvasView drawing process-wide on device (#187).
+        let image = await MainActor.run {
             drawing.image(from: drawing.bounds, scale: 1.0)
-        }.value
+        }
         cache.setObject(image, forKey: key)
         return image
     }


### PR DESCRIPTION
Closes #187

## Problem

Since #174, the canvas is completely broken on a real iPad: Apple Pencil strokes are not drawn, and opening an existing note shows a blank canvas. The bug does not reproduce in the Simulator or in unit tests.

`ThumbnailCache` (ad08d59) renders `PKDrawing.image(from:scale:)` on a background thread via `Task.detached`. PencilKit keeps process-wide renderer state, and once a thumbnail has been rendered off the main thread on device, `PKCanvasView` stops drawing strokes entirely. The on-device bisect that isolated this is documented in #187.

## Fix

Render the thumbnail inside `MainActor.run` instead of `Task.detached` — a one-hunk change in `ThumbnailCache`. The render is still deferred out of view-body evaluation and cached (preserving the intent of #173/#174), but the actual PencilKit call happens on the main thread.

## Verification

- On-device (iPad + Apple Pencil): this exact tree was built and verified — Pencil drawing and existing-note display both work again. With the same base and the thumbnail change reverted, they do not.
- Full unit test suite passes (38 tests); Simulator build clean.

Supersedes #188, which additionally reverted the `CanvasView` `GeometryReader` introduced in ed948fc; the final isolation test showed the thumbnail fix alone is sufficient on `main`.
