### PR TITLE
Document on-device verification requirement for PencilKit changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,7 @@
 
 - All GitHub-facing text is written in English: PR titles/bodies, issue titles/bodies, commit messages, and code comments.
 - Conversation with the user may be in Japanese; the repository's written artifacts stay in English.
+
+## Verification
+
+- Changes that touch the canvas or PencilKit rendering (PKCanvasView, PKDrawing, thumbnails) must be verified on a physical iPad with an Apple Pencil before merge. PencilKit keeps process-wide renderer state that the Simulator and unit tests cannot exercise — rendering `PKDrawing.image` off the main thread breaks stroke drawing app-wide on device only (#187).


### PR DESCRIPTION
Closes #190

Adds a Verification section to CLAUDE.md requiring physical-iPad verification for changes touching the canvas or PencilKit rendering. Motivated by #187, a device-only regression (off-main PKDrawing.image rendering breaking PKCanvasView drawing app-wide) that the Simulator and unit tests could not catch. Documentation only — no code changes.