### PR TITLE
Enumerate iCloud notes via NSMetadataQuery so undownloaded notes stay listed

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		A6F6ED4B27C77A7500DD3296 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F6ED4A27C77A7500DD3296 /* RootView.swift */; };
 		A6FD03422D3FAD8600224B03 /* NoteListTagHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FD03412D3FAD8600224B03 /* NoteListTagHStack.swift */; };
 		A70000000000000000000011 /* NoteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000001 /* NoteRepository.swift */; };
+		A70000000000000000000061 /* CloudNoteMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000051 /* CloudNoteMonitor.swift */; };
 		A70000000000000000000012 /* TagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000002 /* TagRepository.swift */; };
 		A70000000000000000000013 /* PreferenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000003 /* PreferenceRepository.swift */; };
 		A70000000000000000000014 /* NoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000004 /* NoteStore.swift */; };
@@ -108,6 +109,7 @@
 		A7000000000000000000000B /* PreferenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStoreTests.swift; sourceTree = "<group>"; };
 		A7000000000000000000000C /* TagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
+		A70000000000000000000051 /* CloudNoteMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudNoteMonitor.swift; sourceTree = "<group>"; };
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -209,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				A70000000000000000000001 /* NoteRepository.swift */,
+				A70000000000000000000051 /* CloudNoteMonitor.swift */,
 				A70000000000000000000002 /* TagRepository.swift */,
 				A70000000000000000000003 /* PreferenceRepository.swift */,
 			);
@@ -442,6 +445,7 @@
 				A64AE9F4275B203A002C66F7 /* NoteEntity.swift in Sources */,
 				A6620E36274C7A3D00C708A2 /* NoteListParentView.swift in Sources */,
 				A70000000000000000000011 /* NoteRepository.swift in Sources */,
+				A70000000000000000000061 /* CloudNoteMonitor.swift in Sources */,
 				A70000000000000000000012 /* TagRepository.swift in Sources */,
 				A70000000000000000000013 /* PreferenceRepository.swift in Sources */,
 				A70000000000000000000014 /* NoteStore.swift in Sources */,

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -10,9 +10,11 @@ import Foundation
 
 enum FilePath {
     static var savingUrl: URL? {
-        PreferenceRepository().getEnablediCloud()
-            ? iCloudUrl ?? documentDirectoryUrl
-            : documentDirectoryUrl
+        isiCloudActive ? iCloudUrl : documentDirectoryUrl
+    }
+
+    static var isiCloudActive: Bool {
+        PreferenceRepository().getEnablediCloud() && iCloudUrl != nil
     }
 
     // url(forUbiquityContainerIdentifier:) is slow and not meant for the main thread,

--- a/PiecesOfPaper/Repository/CloudNoteMonitor.swift
+++ b/PiecesOfPaper/Repository/CloudNoteMonitor.swift
@@ -1,0 +1,81 @@
+//
+//  CloudNoteMonitor.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+
+/// Enumerates note files through the iCloud metadata index instead of the
+/// local file system, so notes that exist in iCloud but are not downloaded
+/// yet (placeholder `.icloud` files) are still visible.
+@MainActor
+final class CloudNoteMonitor {
+    private let query = NSMetadataQuery()
+    private var observers: [NSObjectProtocol] = []
+    private var hasGathered = false
+    private var gatherWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var fileUrls: [URL] = []
+    var onUpdate: (@MainActor () -> Void)?
+
+    init() {
+        query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+        query.predicate = NSPredicate(format: "%K LIKE '*.plist'", NSMetadataItemFSNameKey)
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(forName: .NSMetadataQueryDidFinishGathering,
+                                            object: query,
+                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.finishGathering() }
+        })
+        observers.append(center.addObserver(forName: .NSMetadataQueryDidUpdate,
+                                            object: query,
+                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.handleUpdate() }
+        })
+        query.start()
+    }
+
+    deinit {
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    /// Waits for the initial gathering so that an in-progress query is never
+    /// mistaken for an empty note list.
+    func urls() async -> [URL] {
+        if !hasGathered {
+            await withCheckedContinuation { gatherWaiters.append($0) }
+        }
+        return fileUrls
+    }
+
+    func stop() {
+        query.stop()
+        resumeGatherWaiters()
+    }
+
+    private func finishGathering() {
+        refreshResults()
+        resumeGatherWaiters()
+    }
+
+    private func handleUpdate() {
+        refreshResults()
+        onUpdate?()
+    }
+
+    private func resumeGatherWaiters() {
+        hasGathered = true
+        gatherWaiters.forEach { $0.resume() }
+        gatherWaiters.removeAll()
+    }
+
+    private func refreshResults() {
+        query.disableUpdates()
+        defer { query.enableUpdates() }
+        fileUrls = query.results.compactMap {
+            ($0 as? NSMetadataItem)?.value(forAttribute: NSMetadataItemURLKey) as? URL
+        }
+    }
+}

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -20,7 +20,8 @@ enum NoteDirectory: String {
 }
 
 protocol NoteRepositoryProtocol: AnyObject {
-    func getFileUrls(directory: NoteDirectory) -> [URL]
+    @MainActor func getFileUrls(directory: NoteDirectory) async -> [URL]
+    @MainActor func setCloudUpdateHandler(_ handler: @escaping @MainActor () -> Void)
     @MainActor func open(fileUrl: URL) async throws -> NoteData
     func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void)
     func delete(fileUrl: URL) throws
@@ -30,18 +31,55 @@ protocol NoteRepositoryProtocol: AnyObject {
 }
 
 final class NoteRepository: NoteRepositoryProtocol {
-    func getFileUrls(directory: NoteDirectory) -> [URL] {
-        guard let directoryUrl = directory.url,
-              var fileNames = try? FileManager.default.contentsOfDirectory(atPath: directoryUrl.path) else { return [] }
+    @MainActor private var cloudMonitor: CloudNoteMonitor?
+    @MainActor private var cloudUpdateHandler: (@MainActor () -> Void)?
+
+    @MainActor
+    func getFileUrls(directory: NoteDirectory) async -> [URL] {
+        guard let directoryUrl = directory.url else { return [] }
+        guard FilePath.isiCloudActive else {
+            stopCloudMonitor()
+            return localFileUrls(in: directoryUrl)
+        }
+        let directoryPath = directoryUrl.resolvingSymlinksInPath().path
+        return await monitor().urls().filter {
+            $0.resolvingSymlinksInPath().deletingLastPathComponent().path == directoryPath
+        }
+    }
+
+    @MainActor
+    func setCloudUpdateHandler(_ handler: @escaping @MainActor () -> Void) {
+        cloudUpdateHandler = handler
+    }
+
+    // Fallback when notes are stored in the local Documents directory,
+    // where NSMetadataQuery finds nothing.
+    private func localFileUrls(in directoryUrl: URL) -> [URL] {
+        guard var fileNames = try? FileManager.default.contentsOfDirectory(atPath: directoryUrl.path) else { return [] }
         fileNames = fileNames.filter { $0.hasSuffix(".plist") }
         return fileNames.map { directoryUrl.appendingPathComponent($0) }
     }
 
     @MainActor
+    private func monitor() -> CloudNoteMonitor {
+        if let cloudMonitor { return cloudMonitor }
+        let monitor = CloudNoteMonitor()
+        monitor.onUpdate = { [weak self] in self?.cloudUpdateHandler?() }
+        cloudMonitor = monitor
+        return monitor
+    }
+
+    @MainActor
+    private func stopCloudMonitor() {
+        cloudMonitor?.stop()
+        cloudMonitor = nil
+    }
+
+    @MainActor
     func open(fileUrl: URL) async throws -> NoteData {
-        guard FileManager.default.fileExists(atPath: fileUrl.path) else {
-            throw NoteRepositoryError.fileNotExist(path: fileUrl.path)
-        }
+        // No fileExists guard: an undownloaded iCloud note has no local file yet.
+        // Kick off the download and let UIDocument's coordinated read wait for it.
+        try? FileManager.default.startDownloadingUbiquitousItem(at: fileUrl)
         let document = NoteDocument(fileURL: fileUrl)
         let isSuccess = await document.open()
         await document.close()
@@ -90,14 +128,11 @@ final class NoteRepository: NoteRepositoryProtocol {
 }
 
 enum NoteRepositoryError: LocalizedError {
-    case fileNotExist(path: String)
     case fileOpenFailed(path: String)
     case directoryNotAvailable
 
     var errorDescription: String? {
         switch self {
-        case .fileNotExist(let path):
-            "File does not exist at \(path)."
         case .fileOpenFailed(let path):
             "Failed to open file at \(path)."
         case .directoryNotAvailable:

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -54,6 +54,10 @@ final class NoteStore {
         self.preferenceRepository = preferenceRepository
         self.inboxListOrder = preferenceRepository.getListOrder(directoryName: NoteDirectory.inbox.rawValue)
         self.archivedListOrder = preferenceRepository.getListOrder(directoryName: NoteDirectory.archived.rawValue)
+        noteRepository.setCloudUpdateHandler { [weak self] in
+            guard let self else { return }
+            Task { await self.applyCloudUpdate() }
+        }
     }
 
     // MARK: - Computed display notes (replaces dual-management)
@@ -89,11 +93,18 @@ final class NoteStore {
 
     // MARK: - Fetch
 
-    func incrementalFetch(directory: NoteDirectory) async {
-        defer { isLoading = false }
-        isLoading = true
-        let (added, removed) = fetchChangedFileUrls(directory: directory)
-        await updateNotes(addedUrls: added, removedUrls: removed, directory: directory)
+    func incrementalFetch(directory: NoteDirectory, background: Bool = false) async {
+        defer { if !background { isLoading = false } }
+        if !background { isLoading = true }
+        let (added, removed) = await fetchChangedFileUrls(directory: directory)
+        await updateNotes(addedUrls: added, removedUrls: removed, directory: directory, background: background)
+    }
+
+    /// Called when the iCloud metadata query reports remote changes,
+    /// so the list follows sync progress without a manual reload.
+    func applyCloudUpdate() async {
+        await incrementalFetch(directory: .inbox, background: true)
+        await incrementalFetch(directory: .archived, background: true)
     }
 
     func reload(directory: NoteDirectory) async {
@@ -108,8 +119,8 @@ final class NoteStore {
         await incrementalFetch(directory: directory)
     }
 
-    private func fetchChangedFileUrls(directory: NoteDirectory) -> (addedUrls: [URL], removedUrls: [URL]) {
-        let latestUrls = noteRepository.getFileUrls(directory: directory)
+    private func fetchChangedFileUrls(directory: NoteDirectory) async -> (addedUrls: [URL], removedUrls: [URL]) {
+        let latestUrls = await noteRepository.getFileUrls(directory: directory)
         let cachedUrls = directory == .inbox ? inboxCachedUrls : archivedCachedUrls
         let oldSet = Set(cachedUrls)
         let latestSet = Set(latestUrls)
@@ -124,7 +135,8 @@ final class NoteStore {
         return (Array(added), Array(removed))
     }
 
-    private func updateNotes(addedUrls: [URL], removedUrls: [URL], directory: NoteDirectory) async {
+    private func updateNotes(addedUrls: [URL], removedUrls: [URL],
+                             directory: NoteDirectory, background: Bool) async {
         let (newNotes, failedUrls) = await withTaskGroup(
             of: (url: URL, note: NoteData?).self
         ) { group -> ([NoteData], [URL]) in
@@ -149,21 +161,25 @@ final class NoteStore {
 
         switch directory {
         case .inbox:
-            inboxNotes += newNotes
+            // Filter re-appends: a cloud update and a user-initiated fetch can
+            // overlap across the awaited opens and resolve the same added URL
+            inboxNotes += newNotes.filter { note in !inboxNotes.contains { $0.id == note.id } }
             // Drop failed URLs from the cache so the next fetch retries them
             inboxCachedUrls.removeAll { failedUrls.contains($0) }
             removedUrls.forEach { url in
                 inboxNotes.removeAll { $0.fileURL == url }
             }
         case .archived:
-            archivedNotes += newNotes
+            archivedNotes += newNotes.filter { note in !archivedNotes.contains { $0.id == note.id } }
             archivedCachedUrls.removeAll { failedUrls.contains($0) }
             removedUrls.forEach { url in
                 archivedNotes.removeAll { $0.fileURL == url }
             }
         }
 
-        if !failedUrls.isEmpty {
+        // Background updates retry failed files on the next query update,
+        // so surfacing an alert for them would only interrupt the user.
+        if !failedUrls.isEmpty && !background {
             alertType = .error(NoteStoreError.openFailed(count: failedUrls.count))
             showAlert = true
         }
@@ -313,7 +329,7 @@ final class NoteStore {
     // MARK: - Canvas support
 
     var canRequestReview: Bool {
-        noteRepository.getFileUrls(directory: .inbox).count >= 5
+        inboxNotes.count >= 5
     }
 
     func save(drawing: PKDrawing, to note: NoteData, completion: @escaping (NoteData?) -> Void) {

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -222,11 +222,33 @@ struct NoteStoreTests {
         #expect(repositoryMock.saveCallCount == callsAfterFirst)
     }
 
-    @Test func test_canRequestReview_requiresFiveInboxFiles() {
-        repositoryMock.fileUrls = (0..<4).map { URL(fileURLWithPath: "/path/to/note\($0).plist") }
+    @Test func test_canRequestReview_requiresFiveInboxNotes() {
+        (0..<4).forEach { _ in noteStore.upsert(NoteData.createTestData()) }
         #expect(!noteStore.canRequestReview)
-        repositoryMock.fileUrls = (0..<5).map { URL(fileURLWithPath: "/path/to/note\($0).plist") }
+        noteStore.upsert(NoteData.createTestData())
         #expect(noteStore.canRequestReview)
+    }
+
+    @Test func test_init_registersCloudUpdateHandler() {
+        #expect(repositoryMock.cloudUpdateHandler != nil)
+    }
+
+    @Test func test_applyCloudUpdate_fetchesNotesWithoutTouchingLoadingState() async {
+        #expect(noteStore.isLoading)
+        await noteStore.applyCloudUpdate()
+        #expect(noteStore.displayInboxNotes.count == 3)
+        #expect(noteStore.isLoading)
+    }
+
+    @Test func test_applyCloudUpdate_suppressesErrorAlertAndRetriesLater() async {
+        repositoryMock.failingUrls = [NoteRepositoryMock.TestFile.file2.url]
+        await noteStore.applyCloudUpdate()
+        #expect(noteStore.displayInboxNotes.count == 2)
+        #expect(!noteStore.showAlert)
+
+        repositoryMock.failingUrls = []
+        await noteStore.applyCloudUpdate()
+        #expect(noteStore.displayInboxNotes.count == 3)
     }
 
     @Test func test_upsert_thenIncrementalFetchDoesNotDuplicate() async {
@@ -261,13 +283,21 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     var failingUrls: Set<URL> = []
     var moveShouldThrow = false
     var fileUrls: [URL]?
+    private(set) var cloudUpdateHandler: (@MainActor () -> Void)?
 
     init(notes: [NoteData]) {
         self.notes = notes
     }
 
-    func getFileUrls(directory: NoteDirectory) -> [URL] {
-        fileUrls ?? TestFile.allCases.map { $0.url }
+    @MainActor
+    func getFileUrls(directory: NoteDirectory) async -> [URL] {
+        guard directory == .inbox else { return [] }
+        return fileUrls ?? TestFile.allCases.map { $0.url }
+    }
+
+    @MainActor
+    func setCloudUpdateHandler(_ handler: @escaping @MainActor () -> Void) {
+        cloudUpdateHandler = handler
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Closes #183

Notes that exist in iCloud but are not downloaded locally appear on disk as `.<name>.plist.icloud` placeholders, so the `contentsOfDirectory`-based enumeration silently dropped them from the list. This PR switches enumeration to `NSMetadataQuery`, which reads the iCloud-side index instead of the local disk.

## Changes

- **`CloudNoteMonitor` (new)** — wraps a long-lived `NSMetadataQuery` scoped to `NSMetadataQueryUbiquitousDocumentsScope` with a `*.plist` predicate. Exposes `urls()` that awaits the initial gathering (so an in-progress query is never mistaken for an empty list) and an `onUpdate` callback fired on `didUpdate` notifications.
- **`NoteRepository.getFileUrls`** is now async. When iCloud is active it filters the query results into Inbox / Archived by parent-directory path (compared through `resolvingSymlinksInPath` to tolerate `/private/var` vs `/var` variants); when iCloud is disabled it falls back to the existing `contentsOfDirectory` path and stops the monitor.
- **`NoteRepository.open`** drops the `fileExists` guard, which failed for placeholder files even with a correct URL. It now calls `startDownloadingUbiquitousItem` (best-effort) and relies on `UIDocument.open()`'s coordinated read to wait for the download. The now-unused `fileNotExist` error case is removed.
- **`NoteStore`** registers a cloud-update handler at init: on each query update it runs an incremental fetch of both directories in background mode — no loading indicator, and open failures are not alerted because the next query update retries them (they are already dropped from the URL cache). The note list now updates live as sync progresses.
- **Duplicate-append guard** in `updateNotes`: a background cloud update and a user-initiated fetch/reload can overlap across the awaited `open()` calls; appends are now deduplicated by note id.
- **`canRequestReview`** is computed from loaded `inboxNotes` instead of a synchronous repository call (the last sync `getFileUrls` caller).

## Behavior changes

- Undownloaded notes now appear in the list, and opening them triggers the download.
- Remote changes (new/deleted notes synced from another device) now show up without a manual reload.
- On a freshly signed-in device, the incremental fetch opens every enumerated note, which downloads all notes proactively.
- Offline with undownloaded notes: a user-initiated fetch still shows the existing "Failed to load N note(s)" alert when opens fail; background sync updates retry silently instead.

## Not included

- Per-item download-state badge in the list (`NSMetadataUbiquitousItemDownloadingStatusKey`), listed as optional in the issue.
- Re-reading notes whose *content* changed remotely; the query diff only handles added/removed URLs.

## Testing

- `xcodebuild test` (iPhone SE 3rd gen simulator): 42 tests, all passing, including new tests for handler registration, background fetch not touching `isLoading`, and alert suppression + retry on background failures.
- Not yet verified on a real device with iCloud sync (evicted/undownloaded files cannot be reproduced in the simulator test environment).
