### PR TITLE
Show note files as drawing thumbnails in the Files app (.pop UTType + QuickLook extensions)

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		A70000000000000000000041 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000031 /* NoteData.swift */; };
 		A70000000000000000000042 /* NoteDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000032 /* NoteDataTests.swift */; };
 		A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000076 /* LegacyNoteMigratorTests.swift */; };
+		A7000000000000000000007B /* NoteRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000007A /* NoteRepositoryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +159,7 @@
 		A70000000000000000000051 /* CloudNoteMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudNoteMonitor.swift; sourceTree = "<group>"; };
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000076 /* LegacyNoteMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigratorTests.swift; sourceTree = "<group>"; };
+		A7000000000000000000007A /* NoteRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRepositoryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -261,6 +263,7 @@
 			children = (
 				A70000000000000000000032 /* NoteDataTests.swift */,
 				A70000000000000000000076 /* LegacyNoteMigratorTests.swift */,
+				A7000000000000000000007A /* NoteRepositoryTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A7000000000000000000000B /* PreferenceStoreTests.swift */,
@@ -564,6 +567,7 @@
 			files = (
 				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
 				A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */,
+				A7000000000000000000007B /* NoteRepositoryTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 				A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */,

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		A7000000000000000000001C /* TagStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000C /* TagStoreTests.swift */; };
 		A70000000000000000000041 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000031 /* NoteData.swift */; };
 		A70000000000000000000042 /* NoteDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000032 /* NoteDataTests.swift */; };
+		A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000076 /* LegacyNoteMigratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -154,6 +155,7 @@
 		A7000000000000000000000C /* TagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000076 /* LegacyNoteMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigratorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				A70000000000000000000032 /* NoteDataTests.swift */,
+				A70000000000000000000076 /* LegacyNoteMigratorTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A7000000000000000000000B /* PreferenceStoreTests.swift */,
@@ -557,6 +560,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
+				A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 				A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */,

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A6620E36274C7A3D00C708A2 /* NoteListParentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E35274C7A3D00C708A2 /* NoteListParentView.swift */; };
 		A6620E3A274C8FA400C708A2 /* NoteDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E39274C8FA400C708A2 /* NoteDocument.swift */; };
 		A6620E3C274CD88000C708A2 /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E3B274CD88000C708A2 /* FilePath.swift */; };
+		A70000000000000000000052 /* LegacyNoteMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000051 /* LegacyNoteMigrator.swift */; };
 		A6BB3DCF2D460C7000FFCB62 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BB3DCE2D460C7000FFCB62 /* TutorialView.swift */; };
 		A6CADA51276752E600657E9E /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA50276752E600657E9E /* SettingView.swift */; };
 		A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6DE5BC32437167E006D3D47 /* Assets.xcassets */; };
@@ -84,6 +85,7 @@
 		A6620E35274C7A3D00C708A2 /* NoteListParentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteListParentView.swift; sourceTree = "<group>"; };
 		A6620E39274C8FA400C708A2 /* NoteDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocument.swift; sourceTree = "<group>"; };
 		A6620E3B274CD88000C708A2 /* FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePath.swift; sourceTree = "<group>"; };
+		A70000000000000000000051 /* LegacyNoteMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigrator.swift; sourceTree = "<group>"; };
 		A6675A37251D89BA00343151 /* PiecesOfPaper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PiecesOfPaper.entitlements; sourceTree = "<group>"; };
 		A66E7512253531440026B9A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A66E7513253538E00026B9A8 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 			isa = PBXGroup;
 			children = (
 				A6620E3B274CD88000C708A2 /* FilePath.swift */,
+				A70000000000000000000051 /* LegacyNoteMigrator.swift */,
 				A63C9592276444CF00822461 /* ListOrder.swift */,
 				A70000000000000000000031 /* NoteData.swift */,
 				A6620E39274C8FA400C708A2 /* NoteDocument.swift */,
@@ -420,6 +423,7 @@
 				A64AE9F22759A963002C66F7 /* NoteView.swift in Sources */,
 				A7000000000000000000001A /* ThumbnailCache.swift in Sources */,
 				A6620E3C274CD88000C708A2 /* FilePath.swift in Sources */,
+				A70000000000000000000052 /* LegacyNoteMigrator.swift in Sources */,
 				A63C9588275DB97900822461 /* DeletableTag.swift in Sources */,
 				A6620E3A274C8FA400C708A2 /* NoteDocument.swift in Sources */,
 				A63C9593276444CF00822461 /* ListOrder.swift in Sources */,

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		A70000000000000000000058 /* NoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64AE9F3275B203A002C66F7 /* NoteEntity.swift */; };
 		A70000000000000000000059 /* TagEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C956C275C7CF300822461 /* TagEntity.swift */; };
 		A7000000000000000000005A /* ThumbnailExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A70000000000000000000055 /* ThumbnailExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A70000000000000000000069 /* PreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000065 /* PreviewProvider.swift */; };
+		A7000000000000000000006A /* NoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64AE9F3275B203A002C66F7 /* NoteEntity.swift */; };
+		A7000000000000000000006B /* TagEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C956C275C7CF300822461 /* TagEntity.swift */; };
+		A7000000000000000000006C /* PreviewExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A70000000000000000000067 /* PreviewExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A6BB3DCF2D460C7000FFCB62 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BB3DCE2D460C7000FFCB62 /* TutorialView.swift */; };
 		A6CADA51276752E600657E9E /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA50276752E600657E9E /* SettingView.swift */; };
 		A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6DE5BC32437167E006D3D47 /* Assets.xcassets */; };
@@ -70,6 +74,13 @@
 			remoteGlobalIDString = A7000000000000000000005E;
 			remoteInfo = ThumbnailExtension;
 		};
+		A70000000000000000000071 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A6DE5BAF2437167C006D3D47 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A70000000000000000000070;
+			remoteInfo = PreviewExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -80,6 +91,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				A7000000000000000000005A /* ThumbnailExtension.appex in Embed App Extensions */,
+				A7000000000000000000006C /* PreviewExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -114,6 +126,9 @@
 		A70000000000000000000053 /* ThumbnailProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailProvider.swift; sourceTree = "<group>"; };
 		A70000000000000000000054 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A70000000000000000000055 /* ThumbnailExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ThumbnailExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A70000000000000000000065 /* PreviewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewProvider.swift; sourceTree = "<group>"; };
+		A70000000000000000000066 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A70000000000000000000067 /* PreviewExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PreviewExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6675A37251D89BA00343151 /* PiecesOfPaper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PiecesOfPaper.entitlements; sourceTree = "<group>"; };
 		A66E7512253531440026B9A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A66E7513253538E00026B9A8 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
@@ -157,6 +172,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A7000000000000000000005C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7000000000000000000006E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -288,12 +310,22 @@
 			path = ThumbnailExtension;
 			sourceTree = "<group>";
 		};
+		A70000000000000000000068 /* PreviewExtension */ = {
+			isa = PBXGroup;
+			children = (
+				A70000000000000000000065 /* PreviewProvider.swift */,
+				A70000000000000000000066 /* Info.plist */,
+			);
+			path = PreviewExtension;
+			sourceTree = "<group>";
+		};
 		A6DE5BAE2437167C006D3D47 = {
 			isa = PBXGroup;
 			children = (
 				A6DE5BB92437167C006D3D47 /* PiecesOfPaper */,
 				A6A16EC325B1673500DF323F /* PiecesOfPaperTests */,
 				A70000000000000000000056 /* ThumbnailExtension */,
+				A70000000000000000000068 /* PreviewExtension */,
 				A6DE5BB82437167C006D3D47 /* Products */,
 				A66E7512253531440026B9A8 /* README.md */,
 				A66E7513253538E00026B9A8 /* LICENSE.md */,
@@ -306,6 +338,7 @@
 				A6DE5BB72437167C006D3D47 /* Pieces of Paper.app */,
 				A6A16EC225B1673500DF323F /* PiecesOfPaperTests.xctest */,
 				A70000000000000000000055 /* ThumbnailExtension.appex */,
+				A70000000000000000000067 /* PreviewExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -363,6 +396,7 @@
 			);
 			dependencies = (
 				A70000000000000000000061 /* PBXTargetDependency */,
+				A70000000000000000000072 /* PBXTargetDependency */,
 			);
 			name = PiecesOfPaper;
 			productName = LikeAPaper;
@@ -384,6 +418,23 @@
 			name = ThumbnailExtension;
 			productName = ThumbnailExtension;
 			productReference = A70000000000000000000055 /* ThumbnailExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		A70000000000000000000070 /* PreviewExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A70000000000000000000075 /* Build configuration list for PBXNativeTarget "PreviewExtension" */;
+			buildPhases = (
+				A7000000000000000000006D /* Sources */,
+				A7000000000000000000006E /* Frameworks */,
+				A7000000000000000000006F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PreviewExtension;
+			productName = PreviewExtension;
+			productReference = A70000000000000000000067 /* PreviewExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -421,6 +472,7 @@
 				A6DE5BB62437167C006D3D47 /* PiecesOfPaper */,
 				A6A16EC125B1673500DF323F /* PiecesOfPaperTests */,
 				A7000000000000000000005E /* ThumbnailExtension */,
+				A70000000000000000000070 /* PreviewExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -443,6 +495,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A7000000000000000000005D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7000000000000000000006F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -480,6 +539,16 @@
 				A70000000000000000000057 /* ThumbnailProvider.swift in Sources */,
 				A70000000000000000000058 /* NoteEntity.swift in Sources */,
 				A70000000000000000000059 /* TagEntity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7000000000000000000006D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A70000000000000000000069 /* PreviewProvider.swift in Sources */,
+				A7000000000000000000006A /* NoteEntity.swift in Sources */,
+				A7000000000000000000006B /* TagEntity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -549,6 +618,11 @@
 			isa = PBXTargetDependency;
 			target = A7000000000000000000005E /* ThumbnailExtension */;
 			targetProxy = A70000000000000000000060 /* PBXContainerItemProxy */;
+		};
+		A70000000000000000000072 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A70000000000000000000070 /* PreviewExtension */;
+			targetProxy = A70000000000000000000071 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -813,6 +887,56 @@
 			};
 			name = Release;
 		};
+		A70000000000000000000073 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 18;
+				DEVELOPMENT_TEAM = JDTR4Y333X;
+				INFOPLIST_FILE = PreviewExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 3.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.PreviewExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A70000000000000000000074 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 18;
+				DEVELOPMENT_TEAM = JDTR4Y333X;
+				INFOPLIST_FILE = PreviewExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 3.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.PreviewExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -848,6 +972,15 @@
 			buildConfigurations = (
 				A70000000000000000000062 /* Debug */,
 				A70000000000000000000063 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A70000000000000000000075 /* Build configuration list for PBXNativeTarget "PreviewExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A70000000000000000000073 /* Debug */,
+				A70000000000000000000074 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		A6620E3A274C8FA400C708A2 /* NoteDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E39274C8FA400C708A2 /* NoteDocument.swift */; };
 		A6620E3C274CD88000C708A2 /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6620E3B274CD88000C708A2 /* FilePath.swift */; };
 		A70000000000000000000052 /* LegacyNoteMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000051 /* LegacyNoteMigrator.swift */; };
+		A70000000000000000000057 /* ThumbnailProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000053 /* ThumbnailProvider.swift */; };
+		A70000000000000000000058 /* NoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64AE9F3275B203A002C66F7 /* NoteEntity.swift */; };
+		A70000000000000000000059 /* TagEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C956C275C7CF300822461 /* TagEntity.swift */; };
+		A7000000000000000000005A /* ThumbnailExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A70000000000000000000055 /* ThumbnailExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A6BB3DCF2D460C7000FFCB62 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BB3DCE2D460C7000FFCB62 /* TutorialView.swift */; };
 		A6CADA51276752E600657E9E /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CADA50276752E600657E9E /* SettingView.swift */; };
 		A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6DE5BC32437167E006D3D47 /* Assets.xcassets */; };
@@ -59,7 +63,28 @@
 			remoteGlobalIDString = A6DE5BB62437167C006D3D47;
 			remoteInfo = PiecesOfPaper;
 		};
+		A70000000000000000000060 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A6DE5BAF2437167C006D3D47 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A7000000000000000000005E;
+			remoteInfo = ThumbnailExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A7000000000000000000005F /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				A7000000000000000000005A /* ThumbnailExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		A62EEAF1273248A300D513B8 /* PiecesOfPaperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiecesOfPaperApp.swift; sourceTree = "<group>"; };
@@ -86,6 +111,9 @@
 		A6620E39274C8FA400C708A2 /* NoteDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocument.swift; sourceTree = "<group>"; };
 		A6620E3B274CD88000C708A2 /* FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePath.swift; sourceTree = "<group>"; };
 		A70000000000000000000051 /* LegacyNoteMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigrator.swift; sourceTree = "<group>"; };
+		A70000000000000000000053 /* ThumbnailProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailProvider.swift; sourceTree = "<group>"; };
+		A70000000000000000000054 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A70000000000000000000055 /* ThumbnailExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ThumbnailExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6675A37251D89BA00343151 /* PiecesOfPaper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PiecesOfPaper.entitlements; sourceTree = "<group>"; };
 		A66E7512253531440026B9A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A66E7513253538E00026B9A8 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
@@ -122,6 +150,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A6DE5BB42437167C006D3D47 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7000000000000000000005C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -244,11 +279,21 @@
 			path = Setting;
 			sourceTree = "<group>";
 		};
+		A70000000000000000000056 /* ThumbnailExtension */ = {
+			isa = PBXGroup;
+			children = (
+				A70000000000000000000053 /* ThumbnailProvider.swift */,
+				A70000000000000000000054 /* Info.plist */,
+			);
+			path = ThumbnailExtension;
+			sourceTree = "<group>";
+		};
 		A6DE5BAE2437167C006D3D47 = {
 			isa = PBXGroup;
 			children = (
 				A6DE5BB92437167C006D3D47 /* PiecesOfPaper */,
 				A6A16EC325B1673500DF323F /* PiecesOfPaperTests */,
+				A70000000000000000000056 /* ThumbnailExtension */,
 				A6DE5BB82437167C006D3D47 /* Products */,
 				A66E7512253531440026B9A8 /* README.md */,
 				A66E7513253538E00026B9A8 /* LICENSE.md */,
@@ -260,6 +305,7 @@
 			children = (
 				A6DE5BB72437167C006D3D47 /* Pieces of Paper.app */,
 				A6A16EC225B1673500DF323F /* PiecesOfPaperTests.xctest */,
+				A70000000000000000000055 /* ThumbnailExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -310,16 +356,35 @@
 				A6DE5BB32437167C006D3D47 /* Sources */,
 				A6DE5BB42437167C006D3D47 /* Frameworks */,
 				A6DE5BB52437167C006D3D47 /* Resources */,
+				A7000000000000000000005F /* Embed App Extensions */,
 				A64AE9F7275C6F00002C66F7 /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				A70000000000000000000061 /* PBXTargetDependency */,
 			);
 			name = PiecesOfPaper;
 			productName = LikeAPaper;
 			productReference = A6DE5BB72437167C006D3D47 /* Pieces of Paper.app */;
 			productType = "com.apple.product-type.application";
+		};
+		A7000000000000000000005E /* ThumbnailExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A70000000000000000000064 /* Build configuration list for PBXNativeTarget "ThumbnailExtension" */;
+			buildPhases = (
+				A7000000000000000000005B /* Sources */,
+				A7000000000000000000005C /* Frameworks */,
+				A7000000000000000000005D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ThumbnailExtension;
+			productName = ThumbnailExtension;
+			productReference = A70000000000000000000055 /* ThumbnailExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -355,6 +420,7 @@
 			targets = (
 				A6DE5BB62437167C006D3D47 /* PiecesOfPaper */,
 				A6A16EC125B1673500DF323F /* PiecesOfPaperTests */,
+				A7000000000000000000005E /* ThumbnailExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -373,6 +439,13 @@
 			files = (
 				A6DE5BC42437167E006D3D47 /* Assets.xcassets in Resources */,
 				A70000000000000000000019 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7000000000000000000005D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,6 +473,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A7000000000000000000005B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A70000000000000000000057 /* ThumbnailProvider.swift in Sources */,
+				A70000000000000000000058 /* NoteEntity.swift in Sources */,
+				A70000000000000000000059 /* TagEntity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A6A16EBE25B1673500DF323F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -461,6 +544,11 @@
 			isa = PBXTargetDependency;
 			target = A6DE5BB62437167C006D3D47 /* PiecesOfPaper */;
 			targetProxy = A6A16EC725B1673500DF323F /* PBXContainerItemProxy */;
+		};
+		A70000000000000000000061 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A7000000000000000000005E /* ThumbnailExtension */;
+			targetProxy = A70000000000000000000060 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -675,6 +763,56 @@
 			};
 			name = Release;
 		};
+		A70000000000000000000062 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 18;
+				DEVELOPMENT_TEAM = JDTR4Y333X;
+				INFOPLIST_FILE = ThumbnailExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 3.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.ThumbnailExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A70000000000000000000063 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 18;
+				DEVELOPMENT_TEAM = JDTR4Y333X;
+				INFOPLIST_FILE = ThumbnailExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 3.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.ThumbnailExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -701,6 +839,15 @@
 			buildConfigurations = (
 				A6DE5BE22437167E006D3D47 /* Debug */,
 				A6DE5BE32437167E006D3D47 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A70000000000000000000064 /* Build configuration list for PBXNativeTarget "ThumbnailExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A70000000000000000000062 /* Debug */,
+				A70000000000000000000063 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PiecesOfPaper/Info.plist
+++ b/PiecesOfPaper/Info.plist
@@ -6,6 +6,21 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Pieces of Paper</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Pieces of Paper Note</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>Individual.LikeAPaper.note</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -66,6 +81,27 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Pieces of Paper Note</string>
+			<key>UTTypeIdentifier</key>
+			<string>Individual.LikeAPaper.note</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pop</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -45,10 +45,13 @@ enum FilePath {
         savingUrl?.appendingPathComponent("Library")
     }
 
+    static let noteFileExtension = "pop"
+    static let legacyNoteFileExtension = "plist"
+
     static var fileName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ssSSSS"
-        return dateFormatter.string(from: Date()) + ".plist"
+        return dateFormatter.string(from: Date()) + "." + noteFileExtension
     }
 
     static var tagListFileUrl: URL? {

--- a/PiecesOfPaper/Model/LegacyNoteMigrator.swift
+++ b/PiecesOfPaper/Model/LegacyNoteMigrator.swift
@@ -1,0 +1,40 @@
+//
+//  LegacyNoteMigrator.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+
+/// Renames legacy `.plist` notes to the current note file extension.
+///
+/// Runs on every enumeration instead of behind a one-time flag: devices on
+/// older app versions keep syncing `.plist` files into the iCloud container,
+/// and undownloaded iCloud placeholders cannot be renamed until they are
+/// materialized. Each call is idempotent and normally a zero-work scan.
+enum LegacyNoteMigrator {
+    static func migrate(in directoryUrl: URL, fileManager: FileManager = .default) {
+        guard let fileNames = try? fileManager.contentsOfDirectory(atPath: directoryUrl.path) else { return }
+        let legacySuffix = "." + FilePath.legacyNoteFileExtension
+        for fileName in fileNames {
+            if fileName.hasSuffix(legacySuffix), !fileName.hasPrefix(".") {
+                let source = directoryUrl.appendingPathComponent(fileName)
+                let destination = source.deletingPathExtension()
+                    .appendingPathExtension(FilePath.noteFileExtension)
+                guard !fileManager.fileExists(atPath: destination.path) else { continue }
+                // Uncoordinated moveItem matches NoteRepository.move; failures
+                // are skipped and retried on the next enumeration.
+                try? fileManager.moveItem(at: source, to: destination)
+            } else if fileName.hasPrefix("."), fileName.hasSuffix(legacySuffix + ".icloud") {
+                // Undownloaded placeholder ".<name>.plist.icloud": request the
+                // download so a later pass can rename the materialized file.
+                let realName = String(fileName.dropFirst().dropLast(".icloud".count))
+                try? fileManager.startDownloadingUbiquitousItem(
+                    at: directoryUrl.appendingPathComponent(realName)
+                )
+            }
+        }
+    }
+}

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -31,9 +31,13 @@ protocol NoteRepositoryProtocol: AnyObject {
 
 final class NoteRepository: NoteRepositoryProtocol {
     func getFileUrls(directory: NoteDirectory) -> [URL] {
-        guard let directoryUrl = directory.url,
-              var fileNames = try? FileManager.default.contentsOfDirectory(atPath: directoryUrl.path) else { return [] }
-        fileNames = fileNames.filter { $0.hasSuffix(".plist") }
+        guard let directoryUrl = directory.url else { return [] }
+        LegacyNoteMigrator.migrate(in: directoryUrl)
+        guard var fileNames = try? FileManager.default.contentsOfDirectory(atPath: directoryUrl.path) else { return [] }
+        fileNames = fileNames.filter {
+            $0.hasSuffix("." + FilePath.noteFileExtension)
+                || $0.hasSuffix("." + FilePath.legacyNoteFileExtension)
+        }
         return fileNames.map { directoryUrl.appendingPathComponent($0) }
     }
 

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -43,9 +43,23 @@ final class NoteRepository: NoteRepositoryProtocol {
             return localFileUrls(in: directoryUrl)
         }
         let directoryPath = directoryUrl.resolvingSymlinksInPath().path
-        return await monitor().urls().filter {
-            $0.resolvingSymlinksInPath().deletingLastPathComponent().path == directoryPath
-        }
+        var seen = Set<URL>()
+        return await monitor().urls()
+            .filter { $0.resolvingSymlinksInPath().deletingLastPathComponent().path == directoryPath }
+            .map(resolveMigratedUrl)
+            .filter { seen.insert($0).inserted }
+    }
+
+    // The metadata query and already-open notes can still hold a pre-rename
+    // .plist URL after LegacyNoteMigrator moved the file. Point such URLs at
+    // the renamed file so enumeration and saves never target a path that no
+    // longer exists (a save to the stale path would fork the note).
+    private func resolveMigratedUrl(_ fileUrl: URL) -> URL {
+        guard fileUrl.pathExtension == FilePath.legacyNoteFileExtension,
+              !FileManager.default.fileExists(atPath: fileUrl.path) else { return fileUrl }
+        let migratedUrl = fileUrl.deletingPathExtension()
+            .appendingPathExtension(FilePath.noteFileExtension)
+        return FileManager.default.fileExists(atPath: migratedUrl.path) ? migratedUrl : fileUrl
     }
 
     @MainActor
@@ -95,12 +109,13 @@ final class NoteRepository: NoteRepositoryProtocol {
     }
 
     func save(_ entity: NoteEntity, to fileUrl: URL, completion: @escaping (Bool) -> Void) {
+        let targetUrl = resolveMigratedUrl(fileUrl)
         // The transient document lives until the completion handler fires,
         // which keeps its conflict observer active for the whole save.
-        let document = NoteDocument(fileURL: fileUrl, entity: entity)
+        let document = NoteDocument(fileURL: targetUrl, entity: entity)
         let saveOperation: UIDocument.SaveOperation =
-            FileManager.default.fileExists(atPath: fileUrl.path) ? .forOverwriting : .forCreating
-        document.save(to: fileUrl, for: saveOperation, completionHandler: completion)
+            FileManager.default.fileExists(atPath: targetUrl.path) ? .forOverwriting : .forCreating
+        document.save(to: targetUrl, for: saveOperation, completionHandler: completion)
     }
 
     func delete(fileUrl: URL) throws {

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -161,20 +161,24 @@ final class NoteStore {
 
         switch directory {
         case .inbox:
+            // Remove before appending: a migration rename arrives as
+            // added(.pop) + removed(.plist) for the same entity id, and the id
+            // filter below would drop the added copy while the old entry is
+            // still in the list.
+            removedUrls.forEach { url in
+                inboxNotes.removeAll { $0.fileURL == url }
+            }
             // Filter re-appends: a cloud update and a user-initiated fetch can
             // overlap across the awaited opens and resolve the same added URL
             inboxNotes += newNotes.filter { note in !inboxNotes.contains { $0.id == note.id } }
             // Drop failed URLs from the cache so the next fetch retries them
             inboxCachedUrls.removeAll { failedUrls.contains($0) }
-            removedUrls.forEach { url in
-                inboxNotes.removeAll { $0.fileURL == url }
-            }
         case .archived:
-            archivedNotes += newNotes.filter { note in !archivedNotes.contains { $0.id == note.id } }
-            archivedCachedUrls.removeAll { failedUrls.contains($0) }
             removedUrls.forEach { url in
                 archivedNotes.removeAll { $0.fileURL == url }
             }
+            archivedNotes += newNotes.filter { note in !archivedNotes.contains { $0.id == note.id } }
+            archivedCachedUrls.removeAll { failedUrls.contains($0) }
         }
 
         // Background updates retry failed files on the next query update,

--- a/PiecesOfPaperTests/LegacyNoteMigratorTests.swift
+++ b/PiecesOfPaperTests/LegacyNoteMigratorTests.swift
@@ -1,0 +1,81 @@
+//
+//  LegacyNoteMigratorTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Pieces_of_Paper
+
+struct LegacyNoteMigratorTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LegacyNoteMigratorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func migrate_renamesLegacyFilePreservingContents() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let contents = Data("note-body".utf8)
+        try contents.write(to: directory.appendingPathComponent("note.plist"))
+
+        LegacyNoteMigrator.migrate(in: directory)
+
+        let renamedUrl = directory.appendingPathComponent("note.pop")
+        #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("note.plist").path))
+        #expect(try Data(contentsOf: renamedUrl) == contents)
+    }
+
+    @Test func migrate_isIdempotent() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("note-body".utf8).write(to: directory.appendingPathComponent("note.plist"))
+
+        LegacyNoteMigrator.migrate(in: directory)
+        LegacyNoteMigrator.migrate(in: directory)
+
+        let fileNames = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(fileNames == ["note.pop"])
+    }
+
+    @Test func migrate_skipsWhenDestinationAlreadyExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let legacyContents = Data("legacy".utf8)
+        let migratedContents = Data("migrated".utf8)
+        try legacyContents.write(to: directory.appendingPathComponent("note.plist"))
+        try migratedContents.write(to: directory.appendingPathComponent("note.pop"))
+
+        LegacyNoteMigrator.migrate(in: directory)
+
+        #expect(try Data(contentsOf: directory.appendingPathComponent("note.plist")) == legacyContents)
+        #expect(try Data(contentsOf: directory.appendingPathComponent("note.pop")) == migratedContents)
+    }
+
+    @Test func migrate_missingDirectoryDoesNothing() {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LegacyNoteMigratorTests-missing-\(UUID().uuidString)")
+
+        LegacyNoteMigrator.migrate(in: directory)
+
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    @Test func migrate_ignoresUnrelatedAndHiddenFiles() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("json".utf8).write(to: directory.appendingPathComponent("taglist.json"))
+        try Data("hidden".utf8).write(to: directory.appendingPathComponent(".hidden.plist"))
+        try Data("pop".utf8).write(to: directory.appendingPathComponent("note.pop"))
+
+        LegacyNoteMigrator.migrate(in: directory)
+
+        let fileNames = try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
+        #expect(fileNames == [".hidden.plist", "note.pop", "taglist.json"])
+    }
+}

--- a/PiecesOfPaperTests/NoteDataTests.swift
+++ b/PiecesOfPaperTests/NoteDataTests.swift
@@ -20,14 +20,14 @@ struct NoteDataTests {
     @Test func isArchived_trueForFileUnderArchivedDirectory() throws {
         let archivedUrl = try #require(FilePath.archivedUrl)
         let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
-                            fileURL: archivedUrl.appendingPathComponent("test.plist"))
+                            fileURL: archivedUrl.appendingPathComponent("test.pop"))
         #expect(note.isArchived)
     }
 
     @Test func isArchived_falseForFileOutsideArchivedDirectory() throws {
         let inboxUrl = try #require(FilePath.inboxUrl)
         let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
-                            fileURL: inboxUrl.appendingPathComponent("test.plist"))
+                            fileURL: inboxUrl.appendingPathComponent("test.pop"))
         #expect(!note.isArchived)
     }
 

--- a/PiecesOfPaperTests/NoteRepositoryTests.swift
+++ b/PiecesOfPaperTests/NoteRepositoryTests.swift
@@ -1,0 +1,62 @@
+//
+//  NoteRepositoryTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Testing
+import Foundation
+import PencilKit
+@testable import Pieces_of_Paper
+
+@MainActor
+struct NoteRepositoryTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NoteRepositoryTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func save(_ entity: NoteEntity, to fileUrl: URL,
+                      with repository: NoteRepository) async -> Bool {
+        await withCheckedContinuation { continuation in
+            repository.save(entity, to: fileUrl) { continuation.resume(returning: $0) }
+        }
+    }
+
+    @Test func save_retargetsStaleLegacyUrlToMigratedFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let migratedUrl = directory.appendingPathComponent("note.pop")
+        try PropertyListEncoder().encode(NoteEntity(drawing: PKDrawing())).write(to: migratedUrl)
+        let staleUrl = directory.appendingPathComponent("note.plist")
+        let entity = NoteEntity(drawing: PKDrawing())
+
+        let success = await save(entity, to: staleUrl, with: NoteRepository())
+
+        #expect(success)
+        #expect(!FileManager.default.fileExists(atPath: staleUrl.path))
+        let saved = try PropertyListDecoder().decode(NoteEntity.self,
+                                                     from: Data(contentsOf: migratedUrl))
+        #expect(saved.id == entity.id)
+    }
+
+    @Test func save_writesToLegacyUrlWhileItStillExists() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let legacyUrl = directory.appendingPathComponent("note.plist")
+        try PropertyListEncoder().encode(NoteEntity(drawing: PKDrawing())).write(to: legacyUrl)
+        let entity = NoteEntity(drawing: PKDrawing())
+
+        let success = await save(entity, to: legacyUrl, with: NoteRepository())
+
+        #expect(success)
+        #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("note.pop").path))
+        let saved = try PropertyListDecoder().decode(NoteEntity.self,
+                                                     from: Data(contentsOf: legacyUrl))
+        #expect(saved.id == entity.id)
+    }
+}

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -141,7 +141,7 @@ struct NoteStoreTests {
     }
 
     @Test func test_upsert_insertsUnknownArchivedNoteIntoArchivedList() throws {
-        let archivedUrl = try #require(FilePath.archivedUrl).appendingPathComponent("archived-note.plist")
+        let archivedUrl = try #require(FilePath.archivedUrl).appendingPathComponent("archived-note.pop")
         let note = NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: archivedUrl)
         noteStore.upsert(note)
         #expect(noteStore.archivedNotes == [note])
@@ -223,9 +223,9 @@ struct NoteStoreTests {
     }
 
     @Test func test_canRequestReview_requiresFiveInboxFiles() {
-        repositoryMock.fileUrls = (0..<4).map { URL(fileURLWithPath: "/path/to/note\($0).plist") }
+        repositoryMock.fileUrls = (0..<4).map { URL(fileURLWithPath: "/path/to/note\($0).pop") }
         #expect(!noteStore.canRequestReview)
-        repositoryMock.fileUrls = (0..<5).map { URL(fileURLWithPath: "/path/to/note\($0).plist") }
+        repositoryMock.fileUrls = (0..<5).map { URL(fileURLWithPath: "/path/to/note\($0).pop") }
         #expect(noteStore.canRequestReview)
     }
 

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Note Preview</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLIsDataBasedPreview</key>
+			<true/>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>Individual.LikeAPaper.note</string>
+			</array>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.preview</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).PreviewProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/PreviewExtension/PreviewProvider.swift
+++ b/PreviewExtension/PreviewProvider.swift
@@ -25,9 +25,13 @@ final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
         // The trait collection carries no display scale in the extension
         // context; every device on this deployment target is at least 2x.
         let displayScale = max(UITraitCollection.current.displayScale, 2)
-        // Cap the longest side in pixels to bound the bitmap (extension memory limit).
-        let maxPixelDimension: CGFloat = 3_072
-        let pixelRatio = min(displayScale, maxPixelDimension / max(contentSize.width, contentSize.height))
+        // Cap the total pixel count, not the longest side: device verification
+        // showed renders around 3.4M pixels get jetsammed in this extension
+        // while ~1M-pixel renders survive. Screen-sized drawings hit full
+        // display scale under a dimension cap and were exactly the ones dying.
+        let maxPixelCount: CGFloat = 2_000_000
+        let areaCap = (maxPixelCount / (contentSize.width * contentSize.height)).squareRoot()
+        let pixelRatio = min(displayScale, areaCap)
         let pixelSize = CGSize(width: contentSize.width * pixelRatio,
                                height: contentSize.height * pixelRatio)
 
@@ -35,20 +39,25 @@ final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
             // Off-main PKDrawing.image is safe here: the extension is a separate
             // process with no PKCanvasView, so the app-side constraint from #187
             // does not apply.
-            var image = UIImage()
-            if hasContent {
-                // Fixed light style so ink drawn in dark mode stays visible on white.
-                UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
-                    image = drawing.image(from: bounds, scale: pixelRatio)
-                }
-            }
-            let format = UIGraphicsImageRendererFormat()
-            format.scale = 1
-            let rendered = UIGraphicsImageRenderer(size: pixelSize, format: format).image { context in
-                UIColor.white.setFill()
-                context.fill(CGRect(origin: .zero, size: pixelSize))
+            var rendered = UIImage()
+            // The pool releases the intermediate PKDrawing bitmap before PNG
+            // encoding, which allocates its own buffer on top.
+            autoreleasepool {
+                var image = UIImage()
                 if hasContent {
-                    image.draw(in: CGRect(origin: .zero, size: pixelSize))
+                    // Fixed light style so ink drawn in dark mode stays visible on white.
+                    UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
+                        image = drawing.image(from: bounds, scale: pixelRatio)
+                    }
+                }
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = 1
+                rendered = UIGraphicsImageRenderer(size: pixelSize, format: format).image { context in
+                    UIColor.white.setFill()
+                    context.fill(CGRect(origin: .zero, size: pixelSize))
+                    if hasContent {
+                        image.draw(in: CGRect(origin: .zero, size: pixelSize))
+                    }
                 }
             }
             guard let pngData = rendered.pngData() else {

--- a/PreviewExtension/PreviewProvider.swift
+++ b/PreviewExtension/PreviewProvider.swift
@@ -21,14 +21,17 @@ final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
         let bounds = drawing.bounds
 
         let hasContent = !bounds.isNull && bounds.width > 0 && bounds.height > 0
-        // Cap the longest side to bound the bitmap size (extension memory limit).
-        let maxDimension: CGFloat = 2_048
-        let ratio = hasContent ? min(1.0, maxDimension / max(bounds.width, bounds.height)) : 1.0
-        let contextSize = hasContent
-            ? CGSize(width: bounds.width * ratio, height: bounds.height * ratio)
-            : CGSize(width: 1_024, height: 768)
+        let contentSize = hasContent ? bounds.size : CGSize(width: 1_024, height: 768)
+        // The trait collection carries no display scale in the extension
+        // context; every device on this deployment target is at least 2x.
+        let displayScale = max(UITraitCollection.current.displayScale, 2)
+        // Cap the longest side in pixels to bound the bitmap (extension memory limit).
+        let maxPixelDimension: CGFloat = 3_072
+        let pixelRatio = min(displayScale, maxPixelDimension / max(contentSize.width, contentSize.height))
+        let pixelSize = CGSize(width: contentSize.width * pixelRatio,
+                               height: contentSize.height * pixelRatio)
 
-        return QLPreviewReply(dataOfContentType: .png, contentSize: contextSize) { _ in
+        return QLPreviewReply(dataOfContentType: .png, contentSize: contentSize) { _ in
             // Off-main PKDrawing.image is safe here: the extension is a separate
             // process with no PKCanvasView, so the app-side constraint from #187
             // does not apply.
@@ -36,16 +39,16 @@ final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
             if hasContent {
                 // Fixed light style so ink drawn in dark mode stays visible on white.
                 UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
-                    image = drawing.image(from: bounds, scale: ratio)
+                    image = drawing.image(from: bounds, scale: pixelRatio)
                 }
             }
             let format = UIGraphicsImageRendererFormat()
             format.scale = 1
-            let rendered = UIGraphicsImageRenderer(size: contextSize, format: format).image { context in
+            let rendered = UIGraphicsImageRenderer(size: pixelSize, format: format).image { context in
                 UIColor.white.setFill()
-                context.fill(CGRect(origin: .zero, size: contextSize))
+                context.fill(CGRect(origin: .zero, size: pixelSize))
                 if hasContent {
-                    image.draw(in: CGRect(origin: .zero, size: contextSize))
+                    image.draw(in: CGRect(origin: .zero, size: pixelSize))
                 }
             }
             guard let pngData = rendered.pngData() else {

--- a/PreviewExtension/PreviewProvider.swift
+++ b/PreviewExtension/PreviewProvider.swift
@@ -11,7 +11,9 @@ import QuickLook
 import PencilKit
 import UniformTypeIdentifiers
 
-final class PreviewProvider: QLPreviewProvider {
+// QLPreviewingController conformance is what exposes providePreview(for:) to
+// the Quick Look host; without it the extension loads but never renders.
+final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
     func providePreview(for request: QLFilePreviewRequest) async throws -> QLPreviewReply {
         let data = try Data(contentsOf: request.fileURL)
         let entity = try PropertyListDecoder().decode(NoteEntity.self, from: data)

--- a/PreviewExtension/PreviewProvider.swift
+++ b/PreviewExtension/PreviewProvider.swift
@@ -1,0 +1,55 @@
+//
+//  PreviewProvider.swift
+//  PreviewExtension
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import UIKit
+import QuickLook
+import PencilKit
+import UniformTypeIdentifiers
+
+final class PreviewProvider: QLPreviewProvider {
+    func providePreview(for request: QLFilePreviewRequest) async throws -> QLPreviewReply {
+        let data = try Data(contentsOf: request.fileURL)
+        let entity = try PropertyListDecoder().decode(NoteEntity.self, from: data)
+        let drawing = entity.drawing
+        let bounds = drawing.bounds
+
+        let hasContent = !bounds.isNull && bounds.width > 0 && bounds.height > 0
+        // Cap the longest side to bound the bitmap size (extension memory limit).
+        let maxDimension: CGFloat = 2_048
+        let ratio = hasContent ? min(1.0, maxDimension / max(bounds.width, bounds.height)) : 1.0
+        let contextSize = hasContent
+            ? CGSize(width: bounds.width * ratio, height: bounds.height * ratio)
+            : CGSize(width: 1_024, height: 768)
+
+        return QLPreviewReply(dataOfContentType: .png, contentSize: contextSize) { _ in
+            // Off-main PKDrawing.image is safe here: the extension is a separate
+            // process with no PKCanvasView, so the app-side constraint from #187
+            // does not apply.
+            var image = UIImage()
+            if hasContent {
+                // Fixed light style so ink drawn in dark mode stays visible on white.
+                UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
+                    image = drawing.image(from: bounds, scale: ratio)
+                }
+            }
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = 1
+            let rendered = UIGraphicsImageRenderer(size: contextSize, format: format).image { context in
+                UIColor.white.setFill()
+                context.fill(CGRect(origin: .zero, size: contextSize))
+                if hasContent {
+                    image.draw(in: CGRect(origin: .zero, size: contextSize))
+                }
+            }
+            guard let pngData = rendered.pngData() else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            return pngData
+        }
+    }
+}

--- a/ThumbnailExtension/Info.plist
+++ b/ThumbnailExtension/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Note Thumbnails</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>Individual.LikeAPaper.note</string>
+			</array>
+			<key>QLThumbnailMinimumDimension</key>
+			<integer>0</integer>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.thumbnail</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ThumbnailProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/ThumbnailExtension/ThumbnailProvider.swift
+++ b/ThumbnailExtension/ThumbnailProvider.swift
@@ -1,0 +1,62 @@
+//
+//  ThumbnailProvider.swift
+//  ThumbnailExtension
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import UIKit
+import QuickLookThumbnailing
+import PencilKit
+
+final class ThumbnailProvider: QLThumbnailProvider {
+    override func provideThumbnail(for request: QLFileThumbnailRequest,
+                                   _ handler: @escaping (QLThumbnailReply?, Error?) -> Void) {
+        let entity: NoteEntity
+        do {
+            let data = try Data(contentsOf: request.fileURL)
+            entity = try PropertyListDecoder().decode(NoteEntity.self, from: data)
+        } catch {
+            handler(nil, error)
+            return
+        }
+
+        let drawing = entity.drawing
+        let bounds = drawing.bounds
+        let maximumSize = request.maximumSize
+
+        guard !bounds.isNull, bounds.width > 0, bounds.height > 0 else {
+            handler(QLThumbnailReply(contextSize: maximumSize) {
+                UIColor.white.setFill()
+                UIRectFill(CGRect(origin: .zero, size: maximumSize))
+                return true
+            }, nil)
+            return
+        }
+
+        let ratio = min(maximumSize.width / bounds.width, maximumSize.height / bounds.height)
+        let drawSize = CGSize(width: bounds.width * ratio, height: bounds.height * ratio)
+        let contextSize = CGSize(width: max(drawSize.width, request.minimumSize.width),
+                                 height: max(drawSize.height, request.minimumSize.height))
+
+        handler(QLThumbnailReply(contextSize: contextSize) {
+            UIColor.white.setFill()
+            UIRectFill(CGRect(origin: .zero, size: contextSize))
+            // Off-main PKDrawing.image is safe here: the extension is a separate
+            // process with no PKCanvasView, so the app-side constraint from #187
+            // does not apply.
+            var image = UIImage()
+            // Fixed light style so ink drawn in dark mode stays visible on white.
+            UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
+                // Render at thumbnail resolution, not native drawing size, to
+                // stay under the extension memory limit.
+                image = drawing.image(from: bounds, scale: ratio * request.scale)
+            }
+            let origin = CGPoint(x: (contextSize.width - drawSize.width) / 2,
+                                 y: (contextSize.height - drawSize.height) / 2)
+            image.draw(in: CGRect(origin: origin, size: drawSize))
+            return true
+        }, nil)
+    }
+}


### PR DESCRIPTION
Closes #184

## Summary

Notes now use a custom `.pop` file extension backed by an exported UTType (`Individual.LikeAPaper.note`), and two QuickLook extensions render them in the Files app: a Thumbnail Extension (drawing shown as the file icon) and a Preview Extension (full-size preview on tap). The on-disk data format is unchanged — still a `PropertyListEncoder`-encoded `NoteEntity`.

## Changes

1. **Custom UTType + `.pop` extension** — `UTExportedTypeDeclarations` (conforms to `public.data` + `public.content`, deliberately not `com.apple.property-list` so system plist handlers don't claim the files) and `CFBundleDocumentTypes` (Editor/Owner) in the app's Info.plist. `FilePath.fileName` now produces `.pop` names.
2. **Legacy migration** — `LegacyNoteMigrator` runs at the top of `NoteRepository.getFileUrls`: renames downloaded `*.plist` notes to `*.pop` and requests download of `.plist.icloud` placeholders so a later pass can rename them. Both enumeration paths accept both suffixes permanently (the `CloudNoteMonitor` NSMetadataQuery predicate from #192 matches `*.pop` and `*.plist`; the local fallback filter does the same), because devices on older app versions can keep syncing `.plist` files into the iCloud container indefinitely — a one-shot flag would be wrong. Idempotent, per-file failures are skipped and retried on the next fetch.
3. **ThumbnailExtension target** (`QLThumbnailProvider`) — decodes `NoteEntity` from the file URL and renders `PKDrawing.image` aspect-fit on a white background, at thumbnail resolution (extension memory cap), with light-mode traits forced so dark-mode ink stays visible.
4. **PreviewExtension target** (`QLPreviewProvider`, data-based PNG reply) — same decode + render at capped full size.
5. **Tests** — fixtures renamed to `.pop`; new `LegacyNoteMigratorTests` covering rename, idempotency, destination-exists skip, missing directory, and unrelated/hidden files.

Both extension targets compile `NoteEntity.swift`/`TagEntity.swift` directly (no shared framework). They need no entitlements — QuickLook hands them a sandbox-readable file URL. `scripts/bump-version.sh` already updates all `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` occurrences globally, so the new targets stay in sync.

Off-main `PKDrawing.image` in the extensions is safe: they are separate processes with no `PKCanvasView`, so the #187 constraint does not apply (noted in code comments).

## Known limitations

- **Old app versions hide `.pop` notes**: the old filter only matches `.plist`, so notes created on the new version are invisible (not deleted) on devices still running an older build; they reappear after updating.
- **Cross-device race can hide the newer copy**: if an old-version device edits a note that a new-version device already migrated, the edit syncs back as a fresh `.plist` next to the `.pop`. Migration skips it (destination exists), and because the list dedups by `entity.id`, only one copy is shown — the other (possibly the newer one) stays hidden until the files are reconciled manually, and deleting the visible copy lets the hidden one reappear on the next reload. No data is destroyed. Accepted as a migration-window conflict, same class as the app's existing "later wins" iCloud conflict policy.
- **Tapping a note in Files opens the app but does not navigate to that note** — `onOpenURL` handling is out of scope here; follow-up tracked in #198.
- **Thumbnails render only where the app is installed** — iCloud.com / a Mac without the app fall back to the generic icon (as stated in the issue).

## Verification

- `plutil -lint` on all Info.plists; clean build after every pbxproj edit; both `.appex` bundles confirmed under `Pieces of Paper.app/PlugIns/`.
- Full test suite passes (44 tests, includes 5 new migrator tests).
- Simulator: seeded a legacy `.plist` note into the app container, launched the app, confirmed it was renamed to `.pop` and still listed.
- **Physical iPad verification required before merge** (CLAUDE.md — PencilKit rendering change):
  1. Existing `.plist` notes are renamed and still open/draw correctly.
  2. Files app → iCloud Drive → Pieces of Paper shows drawing thumbnails.
  3. Tapping a file shows the full-size preview.
  4. Canvas stroke drawing still works after thumbnails have been generated (#187-class regression check).
  - Note: LaunchServices/QuickLook cache aggressively — if thumbnails don't appear, delete/reinstall the app or reboot before concluding failure.
