### PR TITLE
Set up Claude Code documentation: GOTCHAS.md and progress log system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,27 @@
 # CLAUDE.md
 
+- Known pitfalls (PencilKit, Xcode, pbxproj): see [docs/GOTCHAS.md](docs/GOTCHAS.md)
+- Progress log: see [docs/PROGRESS.md](docs/PROGRESS.md). When resuming work, read its Current Status and any unconsolidated fragments in [docs/progress/](docs/progress/)
+
 ## Language
 
 - All GitHub-facing text is written in English: PR titles/bodies, issue titles/bodies, commit messages, and code comments.
 - Conversation with the user may be in Japanese; the repository's written artifacts stay in English.
 
+## Build & test
+
+```
+xcodebuild -project <absolute path>/PiecesOfPaper.xcodeproj -scheme PiecesOfPaper \
+  -destination 'platform=iOS Simulator,name=<simulator name>' build   # or: test
+```
+
+- Pass `-project` as an absolute path; the `platform=iOS Simulator,` prefix is required (see docs/GOTCHAS.md for both).
+
 ## Verification
 
-- Changes that touch the canvas or PencilKit rendering (PKCanvasView, PKDrawing, thumbnails) must be verified on a physical iPad with an Apple Pencil before merge. PencilKit keeps process-wide renderer state that the Simulator and unit tests cannot exercise — rendering `PKDrawing.image` off the main thread breaks stroke drawing app-wide on device only (#187).
+- Changes that touch the canvas or PencilKit rendering (PKCanvasView, PKDrawing, thumbnails) must be verified on a physical iPad with an Apple Pencil before merge. PencilKit keeps process-wide renderer state that the Simulator and unit tests cannot exercise — rendering `PKDrawing.image` off the main thread breaks stroke drawing app-wide on device only (#187). More PencilKit pitfalls: docs/GOTCHAS.md.
+
+## Progress workflow
+
+- Every PR includes one new fragment file `docs/progress/YYYY-MM-DD-<slug>.md` instead of editing `docs/PROGRESS.md` directly (format: [docs/progress/README.md](docs/progress/README.md)).
+- In `docs/PROGRESS.md`, only the Current Status section is edited by hand. The Work Log is written exclusively by `swift scripts/consolidate-progress.swift`, run on the user's request, one run at a time, with the result in a chore PR.

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -1,0 +1,28 @@
+# GOTCHAS
+
+Pitfalls encountered during development, split out of [CLAUDE.md](../CLAUDE.md).
+Each entry links to the issue/PR where the details live.
+
+## PencilKit / Canvas
+
+- **Never call `PKDrawing.image(from:scale:)` off the main actor**: calling it even once from a background context (e.g. `Task.detached`) breaks `PKCanvasView` stroke rendering process-wide — the Pencil stops drawing and existing notes render blank. Device-only; the Simulator and unit tests cannot reproduce it. Render thumbnails via `MainActor.run`. Details: issue #187, PR #189.
+- **Don't trust a single on-device OK/NG observation while bisecting**: during the #187 bisect, wrapping `CanvasView` in `GeometryReader` looked like an independent cause, but an isolation build (main + thumbnail fix only) drew fine — the observation was flaky. Before shipping a fix, back each suspected cause with an isolation build that adds/removes only that element.
+- **`PKDrawing(strokes:)` crashes in the macOS `swift` interpreter**: PKReplicaManager touches CFPreferences and crashes when a drawing with strokes is created from a script. When seeding note files from macOS, use an empty `PKDrawing()` — thumbnails come out blank, but that is enough to exercise the list pipeline.
+
+## SwiftUI
+
+- **Alerts attached below a `fullScreenCover` never show while the cover is up**: `NoteListParentView` has `.alert(isPresented: $noteStore.showAlert)`, but while `CanvasView` is presented via `.fullScreenCover`, that alert is not displayed. Do not refactor cover-side errors onto the store's `showAlert`/`alertType` pattern — errors shown on top of a cover must live in a view-local `@State` + `.alert` inside the cover. The store alert pattern is for the list screens only. Background: PR #186 review.
+
+## Xcode / build
+
+- **`-destination` needs the `platform=iOS Simulator,` prefix**: without it, destination resolution is flaky ("Unable to find a destination" appears intermittently).
+- **Xcode 26.6 (iOS 26.5 SDK) fails asset catalog compilation without the matching simulator runtime**: actool's `CompileAssetCatalogVariant thinned` step always fails when the iOS 26.5 simulator runtime is not installed, even though Swift compilation succeeds. Fix: `xcodebuild -downloadPlatform iOS` (~8.5 GB).
+- **Checking out commits older than mid-2026 loses the shared scheme**: `PiecesOfPaper.xcodeproj/xcshareddata/xcschemes/PiecesOfPaper.xcscheme` was untracked (excluded by `.gitignore`) until July 2026. Checking out an older commit (e.g. tag 3.3.0) leaves Xcode with "No Scheme". Recover with `git show <newer-commit>:PiecesOfPaper.xcodeproj/xcshareddata/xcschemes/PiecesOfPaper.xcscheme` — the target IDs are unchanged. When switching back, delete the now-untracked scheme first or it blocks the checkout.
+- **The bundle ID is `Individual.LikeAPaper`**, kept from the app's previous name. Anything keyed by bundle ID (simulator `defaults`, app containers) uses this, not `PiecesOfPaper`.
+
+## project.pbxproj
+
+- **Never match pbxproj lines by substring when editing with a script**: a filter on lines containing `SettingViewModel.swift` also matched `ListOrderSettingViewModel.swift` and deleted it. Match exactly, by object ID or by the `/* Foo.swift */` comment form.
+- **Verify pbxproj edits with a clean build**: an incremental build can hide a file dropped from Sources behind a stale swiftmodule.
+- **Object IDs look sequential but have gaps**: IDs of the form `A700000000000000000000XX` skip values that are already in use. Before assigning a new one, confirm it is unused with `rg`.
+- **Pass `-project` as an absolute path in worktree sessions**: both the main checkout and worktrees contain `PiecesOfPaper.xcodeproj`, and the shell cwd can silently revert to the launch directory, making xcodebuild build the wrong tree — especially dangerous for background runs.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,42 @@
+# Development Progress Log
+
+Where to resume in the next session. Read **Current Status** first, then check
+[docs/progress/](progress/) for fragments not yet consolidated into the Work Log.
+
+Only Current Status is edited by hand. The Work Log is appended to exclusively by
+`swift scripts/consolidate-progress.swift` (see [progress/README.md](progress/README.md)).
+
+## Current Status
+
+- Phase: post-migration cleanup and feature work. The View + Store + Repository migration is complete (ViewModels removed in PR #186).
+- The device-only canvas breakage from off-main thumbnail rendering is fixed (issue #187, PR #189), and the on-device verification rule for PencilKit changes is documented in CLAUDE.md (PR #191).
+- Latest merge: iCloud notes are enumerated via NSMetadataQuery so undownloaded notes stay listed (PR #192).
+- Next: the only open issue is #184 — show note files as drawing thumbnails in the Files app (custom UTType + QuickLook Thumbnail Extension).
+
+## Work Log
+
+### 2026-07-19
+
+- [x] Enumerate iCloud notes via NSMetadataQuery so undownloaded notes stay listed (PR #192)
+- [x] Document on-device verification requirement for PencilKit changes (PR #191)
+- [x] Render note thumbnails on the main actor to fix broken Pencil drawing on device (issue #187, PR #189)
+  - Root cause: off-main `PKDrawing.image` breaks PKCanvasView rendering process-wide, device-only — see docs/GOTCHAS.md
+- [x] Remove remaining ViewModels to complete the View + Store + Repository migration (PR #186)
+
+### 2026-07-18
+
+- [x] Remove racy post-close refetch that could hide a just-saved note (issue #164, PR #182)
+- [x] Add CLAUDE.md documenting the English-language convention (issue #180, PR #181)
+- [x] Separate NoteDocument responsibilities: file I/O vs view state (PR #179)
+- [x] Add unit tests for Store-layer persistence (issue #177, PR #178)
+
+### 2026-07-12
+
+- [x] Restore SwiftLint and CI, clean up stale project naming (PR #176)
+- [x] Cache note thumbnails and the iCloud container URL (PR #174)
+- [x] Add privacy manifest, VoiceOver labels, and drop deprecated UIScreen.main (PR #172)
+
+### 2026-07-11
+
+- [x] Fix silent data-loss paths in note persistence (PR #170)
+- [x] Complete the Store/Repository architecture migration (PR #168)

--- a/docs/progress/2026-07-19-claude-code-docs.md
+++ b/docs/progress/2026-07-19-claude-code-docs.md
@@ -1,0 +1,1 @@
+- [x] Set up Claude Code documentation: GOTCHAS.md and the progress log system (issue #194, PR #195)

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -1,0 +1,23 @@
+# Progress fragments
+
+Holding area for entries that have not yet been consolidated into the Work Log of
+[docs/PROGRESS.md](../PROGRESS.md). Each PR adds one new file here instead of
+appending to PROGRESS.md directly, so parallel PRs never conflict on the same file.
+
+## Writing a fragment
+
+- File name: `YYYY-MM-DD-<slug>.md` — the date is the work date, the slug is a short identifier such as the branch name.
+- Body: bullet list only, same format as the Work Log. No headings (`#`).
+
+```markdown
+- [x] Add some feature (issue #N, PR #M)
+  - Notes on key decisions, if any
+```
+
+## Consolidation
+
+`swift scripts/consolidate-progress.swift` merges fragments into the
+`### YYYY-MM-DD` sections of the PROGRESS.md Work Log (newest date first,
+appending to an existing section for the same date) and deletes the files it
+consumed. Run it only when the user asks, one run at a time, and put the result
+in a chore PR.

--- a/scripts/consolidate-progress.swift
+++ b/scripts/consolidate-progress.swift
@@ -1,0 +1,175 @@
+// Consolidates docs/progress/ fragment files into the Work Log of docs/PROGRESS.md.
+//
+// Usage (from the repository root):
+//   swift scripts/consolidate-progress.swift
+//
+// Flow: group docs/progress/YYYY-MM-DD-<slug>.md by date, merge them into the
+// "## Work Log" section newest date first (appending to an existing section for
+// the same date), then delete the consumed fragments. Does nothing when there
+// are no fragments. Run only when the user asks, one run at a time; put the
+// result in a chore PR.
+
+import Foundation
+
+let progressPath = "docs/PROGRESS.md"
+let fragmentsDir = "docs/progress"
+let logHeading = "## Work Log"
+
+let fragmentNamePattern = #/^(\d{4}-\d{2}-\d{2})-.+\.md$/#
+let sectionHeadingPattern = #/^### (\d{4}-\d{2}-\d{2})(?:\s|$)/#
+
+struct Fragment {
+    let date: String
+    let body: String
+}
+
+final class Section {
+    let date: String
+    let headingLine: String
+    var bodyLines: [String]
+
+    init(date: String, headingLine: String, bodyLines: [String]) {
+        self.date = date
+        self.headingLine = headingLine
+        self.bodyLines = bodyLines
+    }
+}
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(1)
+}
+
+func trimTrailingBlank(_ lines: inout [String]) {
+    while let last = lines.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+        lines.removeLast()
+    }
+}
+
+func stripLeadingBlank(_ lines: [String]) -> [String] {
+    var start = 0
+    while start < lines.count, lines[start].trimmingCharacters(in: .whitespaces).isEmpty {
+        start += 1
+    }
+    return Array(lines[start...])
+}
+
+func parseFragment(name: String, content: String) -> Fragment {
+    guard let match = name.wholeMatch(of: fragmentNamePattern) else {
+        fail("\(fragmentsDir)/\(name) does not match the naming rule YYYY-MM-DD-<slug>.md")
+    }
+    var lines = content.components(separatedBy: "\n")
+    trimTrailingBlank(&lines)
+    let body = stripLeadingBlank(lines).joined(separator: "\n")
+    if body.isEmpty {
+        fail("\(fragmentsDir)/\(name) is empty")
+    }
+    if body.components(separatedBy: "\n").contains(where: { $0.hasPrefix("#") }) {
+        fail("\(fragmentsDir)/\(name) contains a heading line (#). Fragments must be bullet lists only")
+    }
+    return Fragment(date: String(match.1), body: body)
+}
+
+func mergeFragments(progressText: String, fragments: [Fragment]) -> String {
+    guard !fragments.isEmpty else { return progressText }
+
+    let lines = progressText.components(separatedBy: "\n")
+    guard let headingIndex = lines.firstIndex(where: {
+        $0.trimmingCharacters(in: .whitespaces) == logHeading
+    }) else {
+        fail("\(progressPath) has no \"\(logHeading)\" heading")
+    }
+
+    // The Work Log region runs from the line after the heading to the next "## " heading or EOF
+    var regionEnd = lines.count
+    for index in (headingIndex + 1)..<lines.count where lines[index].hasPrefix("## ") {
+        regionEnd = index
+        break
+    }
+
+    var sections: [Section] = []
+    for index in (headingIndex + 1)..<regionEnd {
+        let line = lines[index]
+        if let match = line.firstMatch(of: sectionHeadingPattern) {
+            sections.append(Section(date: String(match.1), headingLine: line, bodyLines: []))
+        } else if let current = sections.last {
+            current.bodyLines.append(line)
+        } else if !line.trimmingCharacters(in: .whitespaces).isEmpty {
+            fail("Work Log region has text before the first ### heading: \"\(line)\"")
+        }
+    }
+
+    var byDate = Dictionary(uniqueKeysWithValues: sections.map { ($0.date, $0) })
+    for fragment in fragments {
+        let bodyLines = fragment.body.components(separatedBy: "\n")
+        if let existing = byDate[fragment.date] {
+            trimTrailingBlank(&existing.bodyLines)
+            existing.bodyLines.append(contentsOf: bodyLines)
+        } else {
+            let section = Section(
+                date: fragment.date,
+                headingLine: "### \(fragment.date)",
+                bodyLines: bodyLines
+            )
+            byDate[fragment.date] = section
+            sections.append(section)
+        }
+    }
+
+    sections.sort { $0.date > $1.date }
+    var regionLines: [String] = []
+    for section in sections {
+        trimTrailingBlank(&section.bodyLines)
+        regionLines.append("")
+        regionLines.append(section.headingLine)
+        regionLines.append("")
+        regionLines.append(contentsOf: stripLeadingBlank(section.bodyLines))
+    }
+    if regionEnd < lines.count {
+        regionLines.append("")
+    }
+
+    let result = (lines[0...headingIndex] + regionLines + lines[regionEnd...])
+        .joined(separator: "\n")
+    return result.hasSuffix("\n") ? result : result + "\n"
+}
+
+let fileManager = FileManager.default
+guard let entries = try? fileManager.contentsOfDirectory(atPath: fragmentsDir) else {
+    fail("Cannot read \(fragmentsDir) — run this script from the repository root")
+}
+let names = entries.filter { $0 != "README.md" && !$0.hasPrefix(".") }.sorted()
+if names.isEmpty {
+    print("No fragments to consolidate.")
+    exit(0)
+}
+
+let fragments = names.map { name -> Fragment in
+    guard let content = try? String(contentsOfFile: "\(fragmentsDir)/\(name)", encoding: .utf8) else {
+        fail("Cannot read \(fragmentsDir)/\(name)")
+    }
+    return parseFragment(name: name, content: content)
+}
+
+guard let progressText = try? String(contentsOfFile: progressPath, encoding: .utf8) else {
+    fail("Cannot read \(progressPath) — run this script from the repository root")
+}
+
+let merged = mergeFragments(progressText: progressText, fragments: fragments)
+do {
+    try merged.write(toFile: progressPath, atomically: true, encoding: .utf8)
+} catch {
+    fail("Failed to write \(progressPath): \(error.localizedDescription)")
+}
+for name in names {
+    do {
+        try fileManager.removeItem(atPath: "\(fragmentsDir)/\(name)")
+    } catch {
+        fail("Merged into \(progressPath) but failed to delete \(fragmentsDir)/\(name): \(error.localizedDescription)")
+    }
+}
+
+print("Consolidated \(names.count) fragment(s) into \(progressPath):")
+for name in names {
+    print("  - \(name)")
+}


### PR DESCRIPTION
Closes #194

## Summary

Sets up repository documentation for Claude Code sessions: a pitfalls reference, a progress log with a fragment-based workflow, and CLAUDE.md as the hub pointing to both. Documentation and one new script only — no app code or project-file changes.

- **`docs/GOTCHAS.md`** (new): known pitfalls with issue/PR references — PencilKit device-only rendering breakage (#187/#189), the `fullScreenCover` vs store-alert trap (#186), Xcode/build quirks, and pbxproj editing hazards.
- **`docs/PROGRESS.md`** (new): Current Status (the only hand-edited section) + Work Log in dated sections, seeded from the merge history since the Store/Repository migration (2026-07-11 onward).
- **`docs/progress/README.md`** (new): each PR adds one `YYYY-MM-DD-<slug>.md` fragment instead of editing PROGRESS.md, so parallel PRs never conflict.
- **`scripts/consolidate-progress.swift`** (new): merges fragments into the Work Log (newest date first, same-date sections merged) and deletes the consumed files. Validates fragment naming/content and fails without touching anything on malformed input. Run via `swift scripts/consolidate-progress.swift` from the repository root, on request only.
- **`CLAUDE.md`**: now links to GOTCHAS/PROGRESS, adds generic build/test commands, and documents the progress workflow. The existing Language and Verification sections are unchanged.

## Verification

- Consolidation script exercised against a copy of the real PROGRESS.md: normal merge (existing date + new date), no-op with zero fragments, and all error paths (bad file name, empty fragment, heading inside a fragment, missing `## Work Log` heading) — each error exits 1 and leaves PROGRESS.md and the fragments untouched.
- `git diff --stat origin/main` confirms only the five files above changed; no build needed.
