### PR TITLE
Make drawing and storage flows testable in the iOS Simulator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ xcodebuild -project <absolute path>/PiecesOfPaper.xcodeproj -scheme PiecesOfPape
 ## Simulator testing
 
 - Drawing: `PKCanvasViewWrapper` sets `drawingPolicy = .anyInput` under `#if targetEnvironment(simulator)`, so mouse drags draw strokes in the Simulator (on device it stays `.pencilOnly` on iPad). This covers the draw → `canvasViewDrawingDidChange` → autosave → thumbnail flow; renderer-state issues still require a device (see Verification).
+- Toggling the tool picker / navigation bar in the Simulator is a **two-finger tap = Option+click** (Simulator-only gesture). Single taps start strokes under `.anyInput` and never reach the `TapGesture` that toggles the UI on device.
 - iCloud: run day-to-day Simulator checks with iCloud disabled in the app's settings — `FilePath.savingUrl` falls back to the local Documents directory and all save/load/archive paths work without an iCloud account. For real sync, sign into an Apple ID in the Simulator and use Features > Trigger iCloud Sync (unreliable; smoke checks only).
 - Unit tests build non-empty drawings with `PKDrawing.stub()` (`PiecesOfPaperTests/PKDrawingStub.swift`); constructing `PKDrawing` needs no Pencil input.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,10 @@
 ## Verification
 
 - Changes that touch the canvas or PencilKit rendering (PKCanvasView, PKDrawing, thumbnails) must be verified on a physical iPad with an Apple Pencil before merge. PencilKit keeps process-wide renderer state that the Simulator and unit tests cannot exercise — rendering `PKDrawing.image` off the main thread breaks stroke drawing app-wide on device only (#187).
+
+## Simulator testing
+
+- Drawing: `PKCanvasViewWrapper` sets `drawingPolicy = .anyInput` under `#if targetEnvironment(simulator)`, so mouse drags draw strokes in the Simulator (on device it stays `.pencilOnly` on iPad). This covers the draw → `canvasViewDrawingDidChange` → autosave → thumbnail flow; renderer-state issues still require a device (see Verification).
+- iCloud: run day-to-day Simulator checks with iCloud disabled in the app's settings — `FilePath.savingUrl` falls back to the local Documents directory and all save/load/archive paths work without an iCloud account. For real sync, sign into an Apple ID in the Simulator and use Features > Trigger iCloud Sync (unreliable; smoke checks only).
+- Unit tests build non-empty drawings with `PKDrawing.stub()` (`PiecesOfPaperTests/PKDrawingStub.swift`); constructing `PKDrawing` needs no Pencil input.
+- `NoteDocument`'s iCloud conflict resolution is not unit-testable: `NSFileVersion.addOfItem(at:withContentsOf:)` — the only API that fabricates file versions — is macOS-only, so iOS tests cannot create conflicting versions. Verify it with two devices syncing over real iCloud.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ xcodebuild -project <absolute path>/PiecesOfPaper.xcodeproj -scheme PiecesOfPape
 - Toggling the tool picker / navigation bar in the Simulator is a **two-finger tap = Option+click** (Simulator-only gesture). Single taps start strokes under `.anyInput` and never reach the `TapGesture` that toggles the UI on device.
 - iCloud: run day-to-day Simulator checks with iCloud disabled in the app's settings — `FilePath.savingUrl` falls back to the local Documents directory and all save/load/archive paths work without an iCloud account. For real sync, sign into an Apple ID in the Simulator and use Features > Trigger iCloud Sync (unreliable; smoke checks only).
 - Unit tests build non-empty drawings with `PKDrawing.stub()` (`PiecesOfPaperTests/PKDrawingStub.swift`); constructing `PKDrawing` needs no Pencil input.
+- Command-line E2E (drawing injection, accessibility assertions) via idb: see [docs/SIMULATOR_E2E.md](docs/SIMULATOR_E2E.md).
 
 ## Progress workflow
 

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		A70000000000000000000016 /* PreferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000006 /* PreferenceStore.swift */; };
 		A70000000000000000000017 /* NoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000007 /* NoteStoreTests.swift */; };
 		A70000000000000000000018 /* NoteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000008 /* NoteDocumentTests.swift */; };
+		A7000000000000000000001D /* PKDrawingStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000D /* PKDrawingStub.swift */; };
 		A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000B /* PreferenceStoreTests.swift */; };
 		A7000000000000000000001C /* TagStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000000C /* TagStoreTests.swift */; };
 		A70000000000000000000041 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000031 /* NoteData.swift */; };
@@ -106,6 +107,7 @@
 		A70000000000000000000006 /* PreferenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStore.swift; sourceTree = "<group>"; };
 		A70000000000000000000007 /* NoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000008 /* NoteDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocumentTests.swift; sourceTree = "<group>"; };
+		A7000000000000000000000D /* PKDrawingStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKDrawingStub.swift; sourceTree = "<group>"; };
 		A7000000000000000000000B /* PreferenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceStoreTests.swift; sourceTree = "<group>"; };
 		A7000000000000000000000C /* TagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 				A70000000000000000000032 /* NoteDataTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
+				A7000000000000000000000D /* PKDrawingStub.swift */,
 				A7000000000000000000000B /* PreferenceStoreTests.swift */,
 				A7000000000000000000000C /* TagStoreTests.swift */,
 				A6A16EC625B1673500DF323F /* Info.plist */,
@@ -407,6 +410,7 @@
 				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
+				A7000000000000000000001D /* PKDrawingStub.swift in Sources */,
 				A7000000000000000000001B /* PreferenceStoreTests.swift in Sources */,
 				A7000000000000000000001C /* TagStoreTests.swift in Sources */,
 			);

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -34,9 +34,13 @@ struct CanvasView: View {
     private var tapGesture: some Gesture {
         TapGesture(count: 1)
             .onEnded { _ in
-                hideExceptPaper.toggle()
-                setToolPickerVisible(!hideExceptPaper)
+                toggleUIVisibility()
             }
+    }
+
+    private func toggleUIVisibility() {
+        hideExceptPaper.toggle()
+        setToolPickerVisible(!hideExceptPaper)
     }
 
     private func setToolPickerVisible(_ isVisible: Bool) {
@@ -83,7 +87,8 @@ struct CanvasView: View {
     private func canvas(windowSize: CGSize) -> some View {
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
-                            saveAction: { save(drawing: $0) })
+                            saveAction: { save(drawing: $0) },
+                            onToggleUI: { toggleUIVisibility() })
         .onAppear {
             canvasView.drawing = note.entity.drawing
             initialContentSize(windowSize: windowSize)

--- a/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
@@ -13,16 +13,19 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
     @Binding private var canvasView: PKCanvasView
     @Binding private var toolPicker: PKToolPicker
     private let saveAction: (PKDrawing) -> Void
+    private let onToggleUI: (() -> Void)?
     private var defaultTool = PKInkingTool(.pen, color: .black, width: 1)
     private var previousTool: PKTool
     private var currentTool: PKTool
 
     init(canvasView: Binding<PKCanvasView>,
          toolPicker: Binding<PKToolPicker>,
-         saveAction: @escaping (PKDrawing) -> Void) {
+         saveAction: @escaping (PKDrawing) -> Void,
+         onToggleUI: (() -> Void)? = nil) {
         self._canvasView = canvasView
         self._toolPicker = toolPicker
         self.saveAction = saveAction
+        self.onToggleUI = onToggleUI
         self.previousTool = defaultTool
         self.currentTool = defaultTool
     }
@@ -61,7 +64,22 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
             let pencilInteraction = UIPencilInteraction()
             pencilInteraction.delegate = self
             parent.canvasView.addInteraction(pencilInteraction)
+
+            #if targetEnvironment(simulator)
+            // Under .anyInput a single tap starts a stroke and never reaches
+            // CanvasView's TapGesture, so the Simulator toggles the UI with a
+            // two-finger tap instead (Option+click)
+            let twoFingerTap = UITapGestureRecognizer(target: self, action: #selector(toggleUI))
+            twoFingerTap.numberOfTouchesRequired = 2
+            parent.canvasView.addGestureRecognizer(twoFingerTap)
+            #endif
         }
+
+        #if targetEnvironment(simulator)
+        @objc private func toggleUI() {
+            parent.onToggleUI?()
+        }
+        #endif
     }
 }
 

--- a/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
@@ -29,9 +29,14 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
 
     func makeUIView(context: Context) -> PKCanvasView {
         canvasView.maximumZoomScale = 8.0
+        #if targetEnvironment(simulator)
+        // The Simulator has no Apple Pencil; allow mouse (finger) input so drawing is testable
+        canvasView.drawingPolicy = .anyInput
+        #else
         if UIDevice.current.userInterfaceIdiom == .pad {
             canvasView.drawingPolicy = .pencilOnly
         }
+        #endif
         toolPicker.showsDrawingPolicyControls = false
         toolPicker.addObserver(canvasView)
         toolPicker.setVisible(false, forFirstResponder: canvasView)

--- a/PiecesOfPaperTests/NoteDocumentTests.swift
+++ b/PiecesOfPaperTests/NoteDocumentTests.swift
@@ -13,12 +13,12 @@ import PencilKit
 
 @MainActor
 struct NoteDocumentTests {
-    private func makeDocument() -> NoteDocument {
+    private func makeDocument(drawing: PKDrawing = PKDrawing()) -> NoteDocument {
         guard let url = URL(string: "file:///test") else {
             fatalError()
         }
 
-        return NoteDocument(fileURL: url, entity: NoteEntity(drawing: PKDrawing()))
+        return NoteDocument(fileURL: url, entity: NoteEntity(drawing: drawing))
     }
 
     @Test func contents_encodesEntity() throws {
@@ -34,6 +34,15 @@ struct NoteDocumentTests {
         let other = makeDocument()
         try other.load(fromContents: data, ofType: nil)
         #expect(other.entity.id == document.entity.id)
+    }
+
+    @Test func load_roundTripsNonEmptyDrawing() throws {
+        let document = makeDocument(drawing: .stub())
+        let data = try #require(try document.contents(forType: "") as? Data)
+        let other = makeDocument()
+        try other.load(fromContents: data, ofType: nil)
+        #expect(!other.entity.drawing.strokes.isEmpty)
+        #expect(other.entity.drawing == document.entity.drawing)
     }
 
     @Test func load_throwsOnGarbageData() {

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -148,18 +148,6 @@ struct NoteStoreTests {
         #expect(noteStore.inboxNotes.isEmpty)
     }
 
-    private func makeDrawing() -> PKDrawing {
-        let point = PKStrokePoint(location: .zero,
-                                  timeOffset: 0,
-                                  size: CGSize(width: 1, height: 1),
-                                  opacity: 1,
-                                  force: 1,
-                                  azimuth: 0,
-                                  altitude: 0)
-        let path = PKStrokePath(controlPoints: [point], creationDate: Date())
-        return PKDrawing(strokes: [PKStroke(ink: PKInk(.pen, color: .black), path: path)])
-    }
-
     @Test func test_saveDrawing_skipsWhenDrawingUnchanged() {
         let note = NoteData.createTestData()
         var saved: NoteData?
@@ -170,7 +158,7 @@ struct NoteStoreTests {
 
     @Test func test_saveDrawing_persistsAndUpsertsOnSuccess() throws {
         let note = NoteData.createTestData()
-        let drawing = makeDrawing()
+        let drawing = PKDrawing.stub()
         var result: NoteData?
         noteStore.save(drawing: drawing, to: note) { result = $0 }
         let saved = try #require(result)
@@ -184,7 +172,7 @@ struct NoteStoreTests {
         let note = NoteData.createTestData()
         var completionCalled = false
         var saved: NoteData?
-        noteStore.save(drawing: makeDrawing(), to: note) {
+        noteStore.save(drawing: PKDrawing.stub(), to: note) {
             saved = $0
             completionCalled = true
         }
@@ -200,7 +188,7 @@ struct NoteStoreTests {
         noteStore.addTag(tag, to: staleSnapshot)
 
         var result: NoteData?
-        noteStore.save(drawing: makeDrawing(), to: staleSnapshot) { result = $0 }
+        noteStore.save(drawing: PKDrawing.stub(), to: staleSnapshot) { result = $0 }
 
         let saved = try #require(result)
         #expect(saved.entity.tags == [tag])
@@ -210,7 +198,7 @@ struct NoteStoreTests {
     @Test func test_saveDrawing_skipsWhenStoreCopyAlreadyHasDrawing() async {
         await noteStore.incrementalFetch(directory: .inbox)
         let staleSnapshot = notes[0]
-        let drawing = makeDrawing()
+        let drawing = PKDrawing.stub()
         var first: NoteData?
         noteStore.save(drawing: drawing, to: staleSnapshot) { first = $0 }
         let callsAfterFirst = repositoryMock.saveCallCount

--- a/PiecesOfPaperTests/PKDrawingStub.swift
+++ b/PiecesOfPaperTests/PKDrawingStub.swift
@@ -1,0 +1,25 @@
+//
+//  PKDrawingStub.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/19.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import PencilKit
+
+extension PKDrawing {
+    static func stub(points: Int = 5) -> PKDrawing {
+        let strokePoints = (0..<points).map {
+            PKStrokePoint(location: CGPoint(x: $0 * 10, y: $0 * 10),
+                          timeOffset: TimeInterval($0) * 0.1,
+                          size: CGSize(width: 3, height: 3),
+                          opacity: 1,
+                          force: 1,
+                          azimuth: 0,
+                          altitude: .pi / 2)
+        }
+        let path = PKStrokePath(controlPoints: strokePoints, creationDate: Date())
+        return PKDrawing(strokes: [PKStroke(ink: PKInk(.pen, color: .black), path: path)])
+    }
+}

--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -1,0 +1,88 @@
+# Driving the app in the iOS Simulator with idb
+
+How to operate the app end-to-end in the Simulator from the command line using
+[idb](https://github.com/facebook/idb) — for Claude Code sessions and other automation
+that cannot click the Simulator window. Verified 2026-07-19: drawing via `idb ui swipe`,
+persistence via autosave, and stroke-level assertions via `idb ui describe-all` all work.
+The one gap is the UI-visibility toggle (see Limitations).
+
+## Setup
+
+Two components. The companion is a one-time install; the client needs a Python <= 3.11
+environment.
+
+```sh
+# Companion (gRPC server that talks to the Simulator)
+brew tap facebook/fb
+brew trust facebook/fb        # Homebrew refuses untrusted third-party taps without this
+brew install idb-companion
+
+# Client — the PyPI package crashes on Python 3.12+ (asyncio.get_event_loop, facebook/idb#896)
+# and the git-main setup.py does not build on 3.14 either. Use a python@3.11 venv:
+brew install python@3.11
+/opt/homebrew/opt/python@3.11/bin/python3.11 -m venv ~/.venvs/idb
+~/.venvs/idb/bin/pip install fb-idb
+```
+
+`idb` auto-spawns a companion for local simulators; no separate server process is needed.
+`idb list-targets` shows simulators and their UDIDs.
+
+## Launching the app
+
+```sh
+UDID=<simulator udid>
+xcrun simctl boot $UDID
+xcrun simctl install $UDID "<DerivedData>/Build/Products/Debug-iphonesimulator/Pieces of Paper.app"
+# Local-storage mode: skip iCloud so all save/load paths hit the local Documents fallback
+xcrun simctl spawn $UDID defaults write Individual.LikeAPaper iCloud_disabled -bool YES
+xcrun simctl launch $UDID Individual.LikeAPaper
+```
+
+The app launches straight into a fullscreen canvas (see "Simulator testing" in
+[CLAUDE.md](../CLAUDE.md)); drawing works immediately because Simulator builds use
+`drawingPolicy = .anyInput`.
+
+## Operating and asserting
+
+All coordinates are in points, not pixels (a screenshot from a 2x device is twice the
+coordinate values).
+
+| Command | Effect |
+|-|-|
+| `idb ui swipe --udid $UDID x1 y1 x2 y2 --duration 0.5` | Draws one stroke on the canvas |
+| `idb ui tap --udid $UDID x y` | Single tap — starts a dot stroke under `.anyInput`, so not usable for the UI toggle |
+| `idb ui key --udid $UDID <HID keycode>` (`--shift/--control/--option/--command`) | Hardware-keyboard event |
+| `idb ui text --udid $UDID "..."` | Types text |
+| `idb ui describe-all --udid $UDID` | Accessibility tree as JSON |
+| `idb screenshot --udid $UDID out.png` | Screenshot |
+
+Assertions that need no screenshot diffing:
+
+- **Strokes**: `describe-all` lists each PencilKit stroke as an element with
+  `AXLabel: "Pen, black"` and a `frame` matching where it was drawn.
+- **Persistence**: autosave writes the note into the app container —
+  `ls "$(xcrun simctl get_app_container $UDID Individual.LikeAPaper data)/Documents/InboxFolder/"`
+  shows a new timestamped `.plist` after drawing.
+
+Verified example: two swipes (`100 300 300 500`, `300 500 150 650`), then `describe-all`
+returned two "Pen, black" elements with matching frames and a new plist appeared in
+InboxFolder.
+
+## Limitations
+
+- **No multi-touch**: idb's HID surface is single-touch (`multi-tap` is sequential taps at
+  one point, not two fingers). The Simulator-only two-finger tap that toggles the tool
+  picker / navigation bar (`CanvasView.toggleUIVisibility`) cannot be injected, so Done,
+  the note list, and settings are currently unreachable from idb. Planned complement: a
+  Simulator-only keyboard shortcut driven by `idb ui key` (issue #196 follow-up).
+- **Companion version**: the brew bottle is idb-companion 1.1.8 (built 2022). Works
+  against the iOS 18.3.1 simulator runtime; not tested against iOS 26.x runtimes.
+- idb cannot inject touches into physical devices (iOS restriction); this workflow is
+  Simulator-only. Canvas changes still require physical-iPad verification per CLAUDE.md.
+
+## References
+
+- [idb documentation](https://fbidb.io/docs/overview/) / [facebook/idb](https://github.com/facebook/idb)
+- Python compatibility: [facebook/idb#896](https://github.com/facebook/idb/issues/896)
+- App-side Simulator behavior: [CLAUDE.md](../CLAUDE.md) "Simulator testing",
+  `PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift`, `PiecesOfPaper/Model/FilePath.swift`

--- a/docs/progress/2026-07-19-simulator-testability.md
+++ b/docs/progress/2026-07-19-simulator-testability.md
@@ -1,4 +1,5 @@
 - [x] Make drawing and storage flows testable in the iOS Simulator (issue #196, PR #197)
   - Simulator builds set `drawingPolicy = .anyInput` so mouse drags draw; device keeps `.pencilOnly`
+  - Simulator-only two-finger tap (Option+click) toggles the tool picker / navigation bar, since single taps draw under `.anyInput`
   - Shared `PKDrawing.stub()` test fixture; non-empty drawing plist round-trip covered in NoteDocumentTests
   - `NoteDocument` conflict resolution stays untestable on iOS (`NSFileVersion.addOfItem` is macOS-only) — recorded in docs/GOTCHAS.md

--- a/docs/progress/2026-07-19-simulator-testability.md
+++ b/docs/progress/2026-07-19-simulator-testability.md
@@ -3,3 +3,4 @@
   - Simulator-only two-finger tap (Option+click) toggles the tool picker / navigation bar, since single taps draw under `.anyInput`
   - Shared `PKDrawing.stub()` test fixture; non-empty drawing plist round-trip covered in NoteDocumentTests
   - `NoteDocument` conflict resolution stays untestable on iOS (`NSFileVersion.addOfItem` is macOS-only) — recorded in docs/GOTCHAS.md
+  - docs/SIMULATOR_E2E.md: idb-based command-line E2E workflow (setup, draw injection, describe-all assertions; UI toggle not injectable yet)


### PR DESCRIPTION
Closes #196

## Summary

Makes the drawing and storage flows exercisable in the iOS Simulator, which previously could not draw at all (no Apple Pencil) and was cumbersome to run against iCloud.

- **Allow any-input drawing in the Simulator** (`PKCanvasViewWrapper.swift`): `drawingPolicy` becomes `.anyInput` under `#if targetEnvironment(simulator)`, so mouse drags draw strokes and exercise the draw → autosave → thumbnail flow. Device behavior is unchanged (`.pencilOnly` on iPad, compile-time guarded).
- **Simulator-only two-finger tap (Option+click) to toggle the UI**: under `.anyInput` a single tap starts a stroke and never reaches the `TapGesture` that shows/hides the tool picker and navigation bar — without an alternative gesture the Simulator cannot open the tool picker or leave the canvas. A `UITapGestureRecognizer` with `numberOfTouchesRequired = 2` (Simulator builds only) calls the same toggle; the toggle logic is extracted into `CanvasView.toggleUIVisibility()` shared by both paths.
- **Shared `PKDrawing.stub()` test fixture** (`PiecesOfPaperTests/PKDrawingStub.swift`): promotes the ad-hoc `makeDrawing()` helper from `NoteStoreTests` to a shared fixture and adds a `NoteDocumentTests` round-trip test asserting a non-empty drawing survives plist encode/decode.
- **Document the Simulator workflow**: new "Simulator testing" section in `CLAUDE.md` (mouse drawing, Option+click UI toggle, iCloud-off local fallback for day-to-day checks, Features > Trigger iCloud Sync for sync smoke checks, device-only boundaries). The NSFileVersion pitfall goes to `docs/GOTCHAS.md` and a progress fragment is added per the new workflow from #195.
- **`docs/SIMULATOR_E2E.md`**: command-line E2E workflow with idb (companion + Python 3.11 client setup, draw injection via `idb ui swipe`, stroke/persistence assertions via `idb ui describe-all` and the app container). Verified end-to-end on 2026-07-19. Known gap: idb has no multi-touch, so the two-finger UI toggle is not injectable yet — a Simulator-only keyboard shortcut is the planned follow-up.

## Not included

Unit tests for `NoteDocument`'s conflict resolution: `NSFileVersion.addOfItem(at:withContentsOf:)` is macOS-only, so iOS tests cannot fabricate conflicting file versions (confirmed by compile error `'addOfItem(at:withContentsOf:options:)' is unavailable in iOS`). Documented in docs/GOTCHAS.md instead.

## Verification

- `xcodebuild test` (iPhone SE 3rd gen Simulator): 43 tests in 5 suites passed.
- Mouse drawing in the Simulator verified manually (user).
- idb flow in docs/SIMULATOR_E2E.md executed for real: two injected swipes rendered as strokes (screenshot + accessibility tree) and autosave produced a new plist in the app container.
- Remaining manual checks: Option+click toggling in the Simulator, and — per CLAUDE.md, since this touches the canvas — a run on a physical iPad with Apple Pencil before merge to confirm `.pencilOnly` behavior and single-tap toggling are intact.
