### PR TITLE
Resolve iCloud conflicts by promoting the newest file version

### DIFF
--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -57,14 +57,39 @@ final class NoteDocument: UIDocument {
     // The later is the winner
     private func resolveConflictIfNeeded() {
         guard documentState.contains(.inConflict) else { return }
+        let conflictVersions = NSFileVersion.unresolvedConflictVersionsOfItem(at: fileURL) ?? []
         do {
+            if let winnerIndex = NoteConflictResolver.newestVersionIndex(
+                currentModificationDate: NSFileVersion.currentVersionOfItem(at: fileURL)?.modificationDate,
+                conflictModificationDates: conflictVersions.map(\.modificationDate)
+            ) {
+                try conflictVersions[winnerIndex].replaceItem(at: fileURL)
+            }
             try NSFileVersion.removeOtherVersionsOfItem(at: fileURL)
-            NSFileVersion.currentVersionOfItem(at: fileURL)?.isResolved = true
+            conflictVersions.forEach { $0.isResolved = true }
         } catch {
-            print("failed to delete conflict versions: ", error.localizedDescription)
+            print("failed to resolve conflict versions: ", error.localizedDescription)
         }
     }
 
+}
+
+enum NoteConflictResolver {
+    /// Returns the index of the conflict version that should replace the current
+    /// version, or nil when the current version is the newest (ties favor current,
+    /// so no file replacement happens unless a strictly newer version exists).
+    static func newestVersionIndex(currentModificationDate: Date?,
+                                   conflictModificationDates: [Date?]) -> Int? {
+        let currentDate = currentModificationDate ?? .distantPast
+        var winner: (index: Int, date: Date)?
+        for (index, date) in conflictModificationDates.enumerated() {
+            let date = date ?? .distantPast
+            if date > (winner?.date ?? currentDate) {
+                winner = (index, date)
+            }
+        }
+        return winner?.index
+    }
 }
 
 enum NoteDocumentError: LocalizedError {

--- a/PiecesOfPaperTests/NoteDocumentTests.swift
+++ b/PiecesOfPaperTests/NoteDocumentTests.swift
@@ -61,3 +61,67 @@ struct NoteDocumentTests {
         }
     }
 }
+
+struct NoteConflictResolverTests {
+    private let base = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    @Test func currentNewest_returnsNil() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: [base.addingTimeInterval(-10), base.addingTimeInterval(-20)]
+        )
+        #expect(index == nil)
+    }
+
+    @Test func conflictNewest_returnsItsIndex() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: [base.addingTimeInterval(-10), base.addingTimeInterval(10)]
+        )
+        #expect(index == 1)
+    }
+
+    @Test func newestAmongMultipleConflicts_wins() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: [
+                base.addingTimeInterval(30),
+                base.addingTimeInterval(50),
+                base.addingTimeInterval(40)
+            ]
+        )
+        #expect(index == 1)
+    }
+
+    @Test func tieWithCurrent_favorsCurrent() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: [base]
+        )
+        #expect(index == nil)
+    }
+
+    @Test func nilCurrentDate_losesToDatedConflict() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: nil,
+            conflictModificationDates: [base]
+        )
+        #expect(index == 0)
+    }
+
+    @Test func nilConflictDates_loseToDatedCurrent() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: [nil, nil]
+        )
+        #expect(index == nil)
+    }
+
+    @Test func emptyConflictList_returnsNil() {
+        let index = NoteConflictResolver.newestVersionIndex(
+            currentModificationDate: base,
+            conflictModificationDates: []
+        )
+        #expect(index == nil)
+    }
+}

--- a/docs/progress/2026-07-20-fix-conflict-latest-wins.md
+++ b/docs/progress/2026-07-20-fix-conflict-latest-wins.md
@@ -1,0 +1,9 @@
+- [x] Fix NoteDocument conflict resolution to actually keep the newest version (issue #200)
+  - `resolveConflictIfNeeded()` claimed "later wins" but unconditionally kept the local
+    current version; it now promotes the newest of current + unresolved conflict versions
+    via `NSFileVersion.replaceItem(at:)` before removing the others.
+  - The pick-newest decision is factored into `NoteConflictResolver.newestVersionIndex`
+    (plain `Date?` values) because conflict versions cannot be fabricated in iOS unit
+    tests; ties favor the current version so no needless file replacement happens.
+  - End-to-end conflict verification still requires two physical devices producing a
+    real iCloud conflict.


### PR DESCRIPTION
## Summary

`NoteDocument.resolveConflictIfNeeded()` claimed "The later is the winner" but unconditionally called `NSFileVersion.removeOtherVersionsOfItem(at:)`, keeping the local current version and silently discarding every other device's edits.

It now:

1. Enumerates `NSFileVersion.unresolvedConflictVersionsOfItem(at:)` and compares `modificationDate` against the current version.
2. Promotes the newest conflict version with `NSFileVersion.replaceItem(at:)` when one is strictly newer than the current version (ties favor current, so no needless file replacement).
3. Removes the other versions and marks the conflict versions `isResolved`, as before.

The pick-newest decision is factored into `NoteConflictResolver.newestVersionIndex(currentModificationDate:conflictModificationDates:)` operating on plain `Date?` values, because conflict versions cannot be fabricated in iOS unit tests (`NSFileVersion.addOfItem` is macOS-only, per #197). Missing modification dates are treated as `distantPast`.

A true `PKDrawing` stroke merge remains out of scope; latest-wins matching the existing comment is the target behavior.

## Testing

- New `NoteConflictResolverTests` suite (7 tests) covers: current newest, conflict newest, newest among multiple conflicts, tie with current, nil current date, nil conflict dates, empty conflict list.
- Full unit test run passes on the iOS Simulator (57 tests in 8 suites).
- Not yet verified end-to-end: producing a real iCloud conflict requires two physical devices (or device + iCloud.com edit). Per CLAUDE.md this needs physical-device verification before merge.

Closes #200
