### PR TITLE
Open the tapped note on the canvas when a .pop file is opened from the Files app

### DIFF
--- a/PiecesOfPaper/Model/NoteData.swift
+++ b/PiecesOfPaper/Model/NoteData.swift
@@ -16,14 +16,26 @@ struct NoteData: Identifiable, Equatable {
     var id: UUID { entity.id }
 
     var isArchived: Bool {
-        guard let archivedUrl = FilePath.archivedUrl else { return false }
-        return fileURL.path.hasPrefix(archivedUrl.path)
+        isUnder(FilePath.archivedUrl)
+    }
+
+    var isInInbox: Bool {
+        isUnder(FilePath.inboxUrl)
+    }
+
+    // Compare resolved paths: URLs delivered by the Files app carry the
+    // /private symlink prefix that FilePath's URLs lack
+    private func isUnder(_ directoryUrl: URL?) -> Bool {
+        guard let directoryUrl else { return false }
+        return fileURL.resolvingSymlinksInPath().path
+            .hasPrefix(directoryUrl.resolvingSymlinksInPath().path)
     }
 }
 
 extension NoteData {
     static func createTestData() -> NoteData {
-        guard let url = URL(string: "file:///test") else {
+        guard let url = FilePath.inboxUrl?
+            .appendingPathComponent("test-\(UUID().uuidString).pop") else {
             fatalError()
         }
 

--- a/PiecesOfPaper/Model/NoteData.swift
+++ b/PiecesOfPaper/Model/NoteData.swift
@@ -24,11 +24,12 @@ struct NoteData: Identifiable, Equatable {
     }
 
     // Compare resolved paths: URLs delivered by the Files app carry the
-    // /private symlink prefix that FilePath's URLs lack
+    // /private symlink prefix that FilePath's URLs lack. The separator suffix
+    // keeps sibling directories like "InboxFolder2" from matching
     private func isUnder(_ directoryUrl: URL?) -> Bool {
         guard let directoryUrl else { return false }
         return fileURL.resolvingSymlinksInPath().path
-            .hasPrefix(directoryUrl.resolvingSymlinksInPath().path)
+            .hasPrefix(directoryUrl.resolvingSymlinksInPath().path + "/")
     }
 }
 

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -100,8 +100,10 @@ final class NoteRepository: NoteRepositoryProtocol {
         try? FileManager.default.startDownloadingUbiquitousItem(at: fileUrl)
         let document = NoteDocument(fileURL: fileUrl)
         let isSuccess = await document.open()
-        await document.close()
+        // Close only after a successful open: close() on a failed document
+        // never calls its completion handler and hangs the caller forever
         if isSuccess {
+            await document.close()
             return NoteData(entity: document.entity, fileURL: fileUrl)
         } else {
             throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -53,8 +53,7 @@ struct SideBarListView: View {
         }
         // Inside the .environment chain: cover content only inherits values
         // injected outside its attachment point
-        .fullScreenCover(item: $noteStore.openedNote,
-                         onDismiss: { noteStore.releaseSecurityScope() }) { note in
+        .fullScreenCover(item: $noteStore.openedNote) { note in
             NavigationStack {
                 CanvasView(note: note)
             }

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -64,6 +64,11 @@ struct SideBarListView: View {
         .onOpenURL { url in
             noteStore.handleIncomingURL(url)
         }
+        .alert("", isPresented: $noteStore.showExternalOpenAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(NoteStoreError.openFailed(count: 1).localizedDescription)
+        }
         .environment(noteStore)
         .environment(tagStore)
         .environment(preferenceStore)

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -53,13 +53,17 @@ struct SideBarListView: View {
         }
         // Inside the .environment chain: cover content only inherits values
         // injected outside its attachment point
-        .fullScreenCover(item: $noteStore.openedNote) { note in
+        .fullScreenCover(item: $noteStore.openedNote,
+                         onDismiss: { noteStore.releaseSecurityScope() }) { note in
             NavigationStack {
                 CanvasView(note: note)
             }
             // CanvasView seeds its @State from init, so an identity change is
             // what swaps the drawing when openedNote is replaced mid-cover
             .id(note.id)
+        }
+        .onOpenURL { url in
+            noteStore.handleIncomingURL(url)
         }
         .environment(noteStore)
         .environment(tagStore)

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -51,6 +51,16 @@ struct SideBarListView: View {
                 Text("Unknown page")
             }
         }
+        // Inside the .environment chain: cover content only inherits values
+        // injected outside its attachment point
+        .fullScreenCover(item: $noteStore.openedNote) { note in
+            NavigationStack {
+                CanvasView(note: note)
+            }
+            // CanvasView seeds its @State from init, so an identity change is
+            // what swaps the drawing when openedNote is replaced mid-cover
+            .id(note.id)
+        }
         .environment(noteStore)
         .environment(tagStore)
         .environment(preferenceStore)

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -355,31 +355,46 @@ final class NoteStore {
     /// await so a later-arriving scenePhase .active cannot race in a blank canvas
     func handleIncomingURL(_ url: URL) {
         guard url.pathExtension == FilePath.noteFileExtension else { return }
+        externalOpenTask?.cancel()
         isHandlingExternalOpen = true
         externalOpenTask = Task { await openExternalNote(url: url) }
     }
 
     func openExternalNote(url: URL) async {
-        defer { isHandlingExternalOpen = false }
+        // A cancelled task no longer owns the flag — the newer external open does
+        defer { if !Task.isCancelled { isHandlingExternalOpen = false } }
         guard openedNote?.fileURL != url else { return }
-        releaseSecurityScope()
+        let noteBeforeOpen = openedNote
         // false means the URL is not security-scoped (the app's own container),
         // so reading can proceed without holding a scope
-        if url.startAccessingSecurityScopedResource() {
-            securityScopedUrl = url
-        }
+        let scopedUrl: URL? = url.startAccessingSecurityScopedResource() ? url : nil
         do {
-            openedNote = try await noteRepository.open(fileUrl: url)
-        } catch {
+            let note = try await noteRepository.open(fileUrl: url)
+            // Discard a superseded result: a newer external open cancelled this
+            // task, or the user opened another note while the open was awaiting
+            // a potentially long iCloud download
+            guard !Task.isCancelled, openedNote?.id == noteBeforeOpen?.id else {
+                scopedUrl?.stopAccessingSecurityScopedResource()
+                return
+            }
+            // Swap scopes only after a successful open: releasing earlier would
+            // break autosave of the still-presented previous note on failure
             releaseSecurityScope()
+            securityScopedUrl = scopedUrl
+            openedNote = note
+        } catch {
+            scopedUrl?.stopAccessingSecurityScopedResource()
+            guard !Task.isCancelled else { return }
             alertType = .error(NoteStoreError.openFailed(count: 1))
             showAlert = true
         }
     }
 
-    /// The scope is held while the note is open: autosave writes back to the
-    /// scoped URL for the whole canvas lifetime
-    func releaseSecurityScope() {
+    /// Held while the note is open (autosave writes back to the scoped URL) and
+    /// released only when the next external open succeeds. Dismissal keeps it:
+    /// releasing there would race the final in-flight autosave, whose sandboxed
+    /// write the revoked scope would deny
+    private func releaseSecurityScope() {
         securityScopedUrl?.stopAccessingSecurityScopedResource()
         securityScopedUrl = nil
     }

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -36,6 +36,9 @@ final class NoteStore {
     private(set) var isHandlingExternalOpen = false
     private(set) var externalOpenTask: Task<Void, Never>?
     private var securityScopedUrl: URL?
+    /// Separate from showAlert: external opens can fail while NoteListParentView
+    /// (the showAlert host) is unmounted, so SideBarListView presents this one
+    var showExternalOpenAlert = false
     var showAlert = false
     var alertType: AlertType?
     var noteToShare: NoteData?
@@ -385,8 +388,7 @@ final class NoteStore {
         } catch {
             scopedUrl?.stopAccessingSecurityScopedResource()
             guard !Task.isCancelled else { return }
-            alertType = .error(NoteStoreError.openFailed(count: 1))
-            showAlert = true
+            showExternalOpenAlert = true
         }
     }
 

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -33,6 +33,9 @@ final class NoteStore {
     /// Single source of truth for canvas presentation: new notes, thumbnail
     /// taps, and external opens all present by assigning this
     var openedNote: NoteData?
+    private(set) var isHandlingExternalOpen = false
+    private(set) var externalOpenTask: Task<Void, Never>?
+    private var securityScopedUrl: URL?
     var showAlert = false
     var alertType: AlertType?
     var noteToShare: NoteData?
@@ -341,10 +344,44 @@ final class NoteStore {
         openedNote = NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: url)
     }
 
-    /// scenePhase .active hook: never stomp an already-open note
+    /// scenePhase .active hook: never stomp an already-open note or an
+    /// in-flight external open
     func openBlankNoteIfIdle() {
-        guard openedNote == nil else { return }
+        guard openedNote == nil, !isHandlingExternalOpen else { return }
         openNewNote()
+    }
+
+    /// Synchronous onOpenURL entry point. Sets the suppression flag before any
+    /// await so a later-arriving scenePhase .active cannot race in a blank canvas
+    func handleIncomingURL(_ url: URL) {
+        guard url.pathExtension == FilePath.noteFileExtension else { return }
+        isHandlingExternalOpen = true
+        externalOpenTask = Task { await openExternalNote(url: url) }
+    }
+
+    func openExternalNote(url: URL) async {
+        defer { isHandlingExternalOpen = false }
+        guard openedNote?.fileURL != url else { return }
+        releaseSecurityScope()
+        // false means the URL is not security-scoped (the app's own container),
+        // so reading can proceed without holding a scope
+        if url.startAccessingSecurityScopedResource() {
+            securityScopedUrl = url
+        }
+        do {
+            openedNote = try await noteRepository.open(fileUrl: url)
+        } catch {
+            releaseSecurityScope()
+            alertType = .error(NoteStoreError.openFailed(count: 1))
+            showAlert = true
+        }
+    }
+
+    /// The scope is held while the note is open: autosave writes back to the
+    /// scoped URL for the whole canvas lifetime
+    func releaseSecurityScope() {
+        securityScopedUrl?.stopAccessingSecurityScopedResource()
+        securityScopedUrl = nil
     }
 
     // MARK: - Canvas support

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -30,7 +30,9 @@ final class NoteStore {
 
     // MARK: - UI state
     var isLoading = true
-    var showCanvasView = false
+    /// Single source of truth for canvas presentation: new notes, thumbnail
+    /// taps, and external opens all present by assigning this
+    var openedNote: NoteData?
     var showAlert = false
     var alertType: AlertType?
     var noteToShare: NoteData?
@@ -324,10 +326,25 @@ final class NoteStore {
         } else if note.isArchived {
             archivedCachedUrls.append(note.fileURL)
             archivedNotes.append(note)
-        } else {
+        } else if note.isInInbox {
             inboxCachedUrls.append(note.fileURL)
             inboxNotes.append(note)
         }
+        // Notes outside both directories (opened in place from the Files app)
+        // are edited at their own URL and never listed
+    }
+
+    // MARK: - Canvas presentation
+
+    func openNewNote() {
+        guard let url = FilePath.inboxUrl?.appendingPathComponent(FilePath.fileName) else { return }
+        openedNote = NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: url)
+    }
+
+    /// scenePhase .active hook: never stomp an already-open note
+    func openBlankNoteIfIdle() {
+        guard openedNote == nil else { return }
+        openNewNote()
     }
 
     // MARK: - Canvas support

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -52,13 +52,6 @@ struct NoteListParentView: View {
         .toolbar {
             toolbarItems
         }
-        .fullScreenCover(isPresented: $noteStore.showCanvasView) {
-            if let path = FilePath.inboxUrl?.appendingPathComponent(FilePath.fileName) {
-                NavigationStack {
-                    CanvasView(note: NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: path))
-                }
-            }
-        }
         .sheet(isPresented: $showListOrderSettingView) {
             NavigationView {
                 ListOrderSettingView(
@@ -111,7 +104,7 @@ struct NoteListParentView: View {
             switch phase {
             case .active:
                 guard !preferenceStore.shouldGrantiCloud else { return }
-                noteStore.showCanvasView = true
+                noteStore.openBlankNoteIfIdle()
             default:
                 break
             }
@@ -151,7 +144,7 @@ struct NoteListParentView: View {
             }
             .accessibilityLabel("More Actions")
             Button {
-                noteStore.showCanvasView = true
+                noteStore.openNewNote()
             } label: {
                 Image(systemName: "square.and.pencil")
             }

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -11,12 +11,12 @@ import PencilKit
 
 struct NoteView: View {
     private(set) var note: NoteData
-    @State private var showCanvasView = false
+    @Environment(NoteStore.self) private var noteStore
     @State private var thumbnail: UIImage?
 
     var body: some View {
         Button(action: {
-            showCanvasView = true
+            noteStore.openedNote = note
         }, label: {
             Group {
                 if let thumbnail {
@@ -34,11 +34,6 @@ struct NoteView: View {
         .accessibilityLabel("Note")
         .task(id: note.entity.updatedDate) {
             thumbnail = await ThumbnailCache.shared.thumbnail(for: note)
-        }
-        .fullScreenCover(isPresented: $showCanvasView) {
-            NavigationView {
-                CanvasView(note: note)
-            }
         }
     }
 }

--- a/PiecesOfPaperTests/NoteDataTests.swift
+++ b/PiecesOfPaperTests/NoteDataTests.swift
@@ -31,6 +31,19 @@ struct NoteDataTests {
         #expect(!note.isArchived)
     }
 
+    @Test func isInInbox_trueForFileUnderInboxDirectory() throws {
+        let inboxUrl = try #require(FilePath.inboxUrl)
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: inboxUrl.appendingPathComponent("test.pop"))
+        #expect(note.isInInbox)
+    }
+
+    @Test func isInInbox_falseForFileOutsideInboxDirectory() throws {
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: URL(fileURLWithPath: "/external/test.pop"))
+        #expect(!note.isInInbox)
+    }
+
     @Test func equatable_detectsEntityChange() {
         let note = NoteData.createTestData()
         var modified = note

--- a/PiecesOfPaperTests/NoteDataTests.swift
+++ b/PiecesOfPaperTests/NoteDataTests.swift
@@ -44,6 +44,14 @@ struct NoteDataTests {
         #expect(!note.isInInbox)
     }
 
+    @Test func isInInbox_falseForSiblingDirectoryWithSharedPrefix() throws {
+        let inboxUrl = try #require(FilePath.inboxUrl)
+        let siblingUrl = URL(fileURLWithPath: inboxUrl.path + "2")
+            .appendingPathComponent("test.pop")
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()), fileURL: siblingUrl)
+        #expect(!note.isInInbox)
+    }
+
     @Test func equatable_detectsEntityChange() {
         let note = NoteData.createTestData()
         var modified = note

--- a/PiecesOfPaperTests/NoteRepositoryTests.swift
+++ b/PiecesOfPaperTests/NoteRepositoryTests.swift
@@ -44,6 +44,33 @@ struct NoteRepositoryTests {
         #expect(saved.id == entity.id)
     }
 
+    @Test func open_readsSavedEntity() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = directory.appendingPathComponent("note.pop")
+        let entity = NoteEntity(drawing: PKDrawing.stub())
+        try PropertyListEncoder().encode(entity).write(to: fileUrl)
+
+        let note = try await NoteRepository().open(fileUrl: fileUrl)
+
+        #expect(note.entity.id == entity.id)
+        #expect(note.entity.drawing == entity.drawing)
+        #expect(note.fileURL == fileUrl)
+    }
+
+    // A missing file is not testable here: open intentionally treats it as an
+    // undownloaded iCloud item and waits for the download indefinitely
+    @Test func open_throwsForCorruptFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let corruptUrl = directory.appendingPathComponent("corrupt.pop")
+        try Data("not a property list".utf8).write(to: corruptUrl)
+
+        await #expect(throws: NoteRepositoryError.self) {
+            _ = try await NoteRepository().open(fileUrl: corruptUrl)
+        }
+    }
+
     @Test func save_writesToLegacyUrlWhileItStillExists() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -285,7 +285,7 @@ struct NoteStoreTests {
         repositoryMock.failingUrls = [NoteRepositoryMock.externalUrl]
         await noteStore.openExternalNote(url: NoteRepositoryMock.externalUrl)
         #expect(noteStore.openedNote == nil)
-        #expect(noteStore.showAlert)
+        #expect(noteStore.showExternalOpenAlert)
     }
 
     @Test func test_openExternalNote_replacesOpenedNote() async {

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -266,6 +266,41 @@ struct NoteStoreTests {
         #expect(noteStore.openedNote == note)
     }
 
+    @Test func test_handleIncomingURL_ignoresNonPopExtension() {
+        noteStore.handleIncomingURL(URL(fileURLWithPath: "/external/legacy.plist"))
+        #expect(noteStore.externalOpenTask == nil)
+        #expect(!noteStore.isHandlingExternalOpen)
+        #expect(noteStore.openedNote == nil)
+    }
+
+    @Test func test_handleIncomingURL_opensPopFileOnCanvas() async {
+        noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl)
+        #expect(noteStore.isHandlingExternalOpen)
+        await noteStore.externalOpenTask?.value
+        #expect(noteStore.openedNote == notes[0])
+        #expect(!noteStore.isHandlingExternalOpen)
+    }
+
+    @Test func test_openExternalNote_showsAlertOnFailure() async {
+        repositoryMock.failingUrls = [NoteRepositoryMock.externalUrl]
+        await noteStore.openExternalNote(url: NoteRepositoryMock.externalUrl)
+        #expect(noteStore.openedNote == nil)
+        #expect(noteStore.showAlert)
+    }
+
+    @Test func test_openExternalNote_replacesOpenedNote() async {
+        noteStore.openNewNote()
+        await noteStore.openExternalNote(url: NoteRepositoryMock.externalUrl)
+        #expect(noteStore.openedNote == notes[0])
+    }
+
+    @Test func test_openBlankNoteIfIdle_skipsWhileHandlingExternalOpen() async {
+        noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl)
+        noteStore.openBlankNoteIfIdle()
+        await noteStore.externalOpenTask?.value
+        #expect(noteStore.openedNote == notes[0])
+    }
+
     @Test func test_upsert_thenIncrementalFetchDoesNotDuplicate() async {
         let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
                             fileURL: NoteRepositoryMock.TestFile.file1.url)
@@ -296,6 +331,10 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         // swiftlint:enable force_unwrapping
     }
 
+    // Outside TestFile: getFileUrls returns TestFile.allCases, and this URL
+    // must never appear in a directory listing
+    static let externalUrl = URL(fileURLWithPath: "/external/file1.pop")
+
     var notes: [NoteData]
     var failingUrls: Set<URL> = []
     var moveShouldThrow = false
@@ -321,6 +360,9 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     func open(fileUrl: URL) async throws -> NoteData {
         if failingUrls.contains(fileUrl) {
             throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)
+        }
+        if fileUrl == Self.externalUrl {
+            return notes[0]
         }
         switch fileUrl.lastPathComponent {
         case "file1":

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -239,6 +239,33 @@ struct NoteStoreTests {
         #expect(noteStore.displayInboxNotes.count == 3)
     }
 
+    @Test func test_upsert_ignoresFileOutsideManagedDirectories() {
+        let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
+                            fileURL: URL(fileURLWithPath: "/external/note.pop"))
+        noteStore.upsert(note)
+        #expect(noteStore.inboxNotes.isEmpty)
+        #expect(noteStore.archivedNotes.isEmpty)
+    }
+
+    @Test func test_openNewNote_presentsBlankNoteInInbox() throws {
+        noteStore.openNewNote()
+        let opened = try #require(noteStore.openedNote)
+        #expect(opened.isInInbox)
+        #expect(opened.entity.drawing.strokes.isEmpty)
+    }
+
+    @Test func test_openBlankNoteIfIdle_opensBlankNoteWhenIdle() {
+        noteStore.openBlankNoteIfIdle()
+        #expect(noteStore.openedNote != nil)
+    }
+
+    @Test func test_openBlankNoteIfIdle_skipsWhenNoteAlreadyOpen() {
+        let note = NoteData.createTestData()
+        noteStore.openedNote = note
+        noteStore.openBlankNoteIfIdle()
+        #expect(noteStore.openedNote == note)
+    }
+
     @Test func test_upsert_thenIncrementalFetchDoesNotDuplicate() async {
         let note = NoteData(entity: NoteEntity(drawing: PKDrawing()),
                             fileURL: NoteRepositoryMock.TestFile.file1.url)
@@ -253,15 +280,17 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     enum TestFile: CaseIterable {
         case file1, file2, file3
 
+        // Fixture URLs live under the inbox directory so upsert treats them as
+        // managed notes (foreign URLs are intentionally never listed)
         // swiftlint:disable force_unwrapping
         var url: URL {
             switch self {
             case .file1:
-                URL(string: "file:///path/to/file1")!
+                FilePath.inboxUrl!.appendingPathComponent("file1")
             case .file2:
-                URL(string: "file:///path/to/file2")!
+                FilePath.inboxUrl!.appendingPathComponent("file2")
             case .file3:
-                URL(string: "file:///path/to/file3")!
+                FilePath.inboxUrl!.appendingPathComponent("file3")
             }
         }
         // swiftlint:enable force_unwrapping

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -294,6 +294,31 @@ struct NoteStoreTests {
         #expect(noteStore.openedNote == notes[0])
     }
 
+    @Test func test_handleIncomingURL_secondRapidOpenWins() async {
+        noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl)
+        let firstTask = noteStore.externalOpenTask
+        noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl2)
+        await firstTask?.value
+        await noteStore.externalOpenTask?.value
+        #expect(noteStore.openedNote == notes[1])
+        #expect(!noteStore.isHandlingExternalOpen)
+    }
+
+    @Test func test_openExternalNote_keepsNoteTheUserOpenedDuringSlowOpen() async {
+        repositoryMock.suspendOpens = true
+        noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl)
+        while !repositoryMock.hasPendingOpen { await Task.yield() }
+
+        let userNote = NoteData.createTestData()
+        noteStore.openedNote = userNote
+        repositoryMock.suspendOpens = false
+        repositoryMock.resumePendingOpens()
+        await noteStore.externalOpenTask?.value
+
+        #expect(noteStore.openedNote == userNote)
+        #expect(!noteStore.isHandlingExternalOpen)
+    }
+
     @Test func test_openBlankNoteIfIdle_skipsWhileHandlingExternalOpen() async {
         noteStore.handleIncomingURL(NoteRepositoryMock.externalUrl)
         noteStore.openBlankNoteIfIdle()
@@ -331,12 +356,21 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         // swiftlint:enable force_unwrapping
     }
 
-    // Outside TestFile: getFileUrls returns TestFile.allCases, and this URL
+    // Outside TestFile: getFileUrls returns TestFile.allCases, and these URLs
     // must never appear in a directory listing
     static let externalUrl = URL(fileURLWithPath: "/external/file1.pop")
+    static let externalUrl2 = URL(fileURLWithPath: "/external/file2.pop")
 
     var notes: [NoteData]
     var failingUrls: Set<URL> = []
+    var suspendOpens = false
+    private var pendingOpens: [CheckedContinuation<Void, Never>] = []
+    var hasPendingOpen: Bool { !pendingOpens.isEmpty }
+
+    func resumePendingOpens() {
+        pendingOpens.forEach { $0.resume() }
+        pendingOpens.removeAll()
+    }
     var moveShouldThrow = false
     var fileUrls: [URL]?
     private(set) var cloudUpdateHandler: (@MainActor () -> Void)?
@@ -358,11 +392,17 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
 
     @MainActor
     func open(fileUrl: URL) async throws -> NoteData {
+        if suspendOpens {
+            await withCheckedContinuation { pendingOpens.append($0) }
+        }
         if failingUrls.contains(fileUrl) {
             throw NoteRepositoryError.fileOpenFailed(path: fileUrl.path)
         }
         if fileUrl == Self.externalUrl {
             return notes[0]
+        }
+        if fileUrl == Self.externalUrl2 {
+            return notes[1]
         }
         switch fileUrl.lastPathComponent {
         case "file1":

--- a/docs/progress/2026-07-20-open-pop-from-files.md
+++ b/docs/progress/2026-07-20-open-pop-from-files.md
@@ -1,0 +1,5 @@
+- [x] Open the tapped note on the canvas when a `.pop` file is opened from the Files app (issue #198, PR #208)
+  - Canvas presentation unified onto a single `fullScreenCover(item: NoteStore.openedNote)` at `SideBarListView`; new note, thumbnail tap, and external open all present by assigning `openedNote`, which removes the onOpenURL vs scenePhase race by construction
+  - Security scope for out-of-container URLs is held by the store while the note is open (autosave writes back to the scoped URL) and released on dismissal
+  - Foreign files (outside Inbox/Archived) open in place and are never inserted into the note lists
+  - Bug fix found by the new tests: `NoteRepository.open` hung forever on unreadable files because `close()` after a failed `open()` never fires its completion handler


### PR DESCRIPTION
Closes #198

10 files changed, +281 / -25 (8 commits)

## What changes against main

### 1. Open tapped `.pop` files from the Files app (the issue itself)
- `SideBarListView` gains an `.onOpenURL` handler; `NoteStore.handleIncomingURL` filters for the `.pop` extension, sets a suppression flag synchronously, and resolves the URL through the existing `NoteRepository.open(fileUrl:)` (which already kicks off `startDownloadingUbiquitousItem`).
- Security-scoped access is held by the store while the note is open (autosave writes back to the scoped URL) and released only when the next external open succeeds — not on dismissal, so an in-flight final autosave is never denied by the sandbox. A `false` return from `startAccessingSecurityScopedResource` means the URL is the app's own container and needs no scope.
- Files outside the app's Inbox/Archived directories open in place but are never inserted into the note lists (`upsert` now checks `isInInbox`); their saves go back to their own URL.
- Legacy `.plist` URLs are ignored (out of scope per the issue).

### 2. Canvas presentation unified onto one item-driven cover ⚠️ behavior-visible
- The three competing `fullScreenCover`s (blank-note Bool in `NoteListParentView`, local `@State` in `NoteView`, plus the third one this feature would have needed) are replaced by a single `fullScreenCover(item: $noteStore.openedNote)` at `SideBarListView`. Two covers cannot present from one host and `onOpenURL` vs `scenePhase == .active` ordering is not guaranteed; with one item-driven cover every race collapses into a state assignment. `.id(note.id)` forces a fresh `CanvasView` when the note is swapped mid-cover.
- **Intentional behavior change**: foregrounding the app while a note is open no longer queues a blank canvas that popped up after tapping Done (previously `showCanvasView = true` was left pending).
- `CanvasView` itself is untouched.

### 3. Bug fix: `NoteRepository.open` hung forever on unreadable files ⚠️
- `document.close()` was called even after a failed `open()`; UIDocument never invokes the close completion handler for a document that never opened, so the caller awaited forever (found because the new repository test hung the test runner both runs). Now close only runs after a successful open. This also fixes the incremental fetch silently hanging on a corrupt note file.

### 4. Model + test infrastructure
- `NoteData.isInInbox` added next to `isArchived`; both compare symlink-resolved paths because Files-delivered URLs carry the `/private` prefix.
- Test fixtures now use unique URLs under the inbox directory instead of the colliding `file:///test` / `file:///path/to/fileN`.
- New tests: external-open flow in `NoteStoreTests` (7, including rapid-double-open and slow-open races), `NoteRepository.open` round-trip + corrupt-file failure (2), `isInInbox` (3), blank-note presentation (3), foreign-URL upsert guard (1). 68 tests pass.

## Code review findings (multi-agent review, verified pass)

Fixed in follow-up commits:
- **Security scope released too early**: `openExternalNote` revoked the current note's scope before knowing the new open would succeed, so a failed second open left the still-presented note scope-less and silently broke its autosave. Scopes now swap only after a successful open.
- **Concurrent external opens not serialized**: two rapid Files taps interleaved two tasks and corrupted the scope bookkeeping and the `isHandlingExternalOpen` flag. `handleIncomingURL` now cancels the previous task; a cancelled task discards its result and leaves the flag alone.
- **Stale-open guard only checked before the await**: a slow iCloud-download open could later stomp a note the user had opened from the list mid-edit (also destroying the active CanvasView's queued save). The result is now discarded if `openedNote` changed while the open was in flight.
- **Failure alert had no reachable host**: the only `.alert` host was `NoteListParentView`, unmounted on the Tag/Tutorial/Setting pages. External-open failures now use a dedicated `showExternalOpenAlert` presented from `SideBarListView`. (While a canvas cover is up, presentation is deferred until dismissal — known GOTCHA, accepted.)
- **`isUnder` prefix false positive**: sibling directories sharing a prefix (e.g. `InboxFolder2/`) matched as managed. The comparison now requires a path separator.

Accepted (not fixed, by decision):
- `upsert` can skip listing a just-saved note if the iCloud preference flips between note creation and save completion (very narrow window).
- `isUnder` resolves symlinks and recomputes `FilePath` URLs on every call (minor, low-frequency).
- `externalOpenTask` is test-facing state on the production store.

## Verification

Simulator (iPhone SE 3rd gen, iCloud off):
- Launch without URL still auto-opens the blank canvas.
- `simctl openurl` with a container `.pop`: opens the tapped note both while the blank canvas is up (content swap) and from cold launch.
- `.plist` URL: ignored, app stays alive.
- Full unit test suite: `** TEST SUCCEEDED **` (68 tests).

Physical iPad + Apple Pencil (verified 2026-07-20, before the review fixes):
- [x] Tap a `.pop` in Files (own container + a copy on "On My iPad" for the security-scope path) → note opens; Pencil strokes render and autosave persists to that file
- [x] Undownloaded iCloud `.pop` (cloud badge) → downloads and opens; failure shows the alert at cold launch
- [x] Thumbnail tap / New Note / Done regression (presentation moved to `SideBarListView`)
- [x] Canvas swap via Files in Split View while another note is open → old strokes persisted, Pencil still draws

The review fixes landed after that device pass and touch only the external-open flow (scope swap timing, task serialization, alert host); a light re-check of "tap a `.pop` in Files → open → draw → reopen" on device is recommended before merge.

