### PR TITLE
Stop overwriting taglist.json with defaults while the iCloud copy is undownloaded

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A70000000000000000000042 /* NoteDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000032 /* NoteDataTests.swift */; };
 		A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000076 /* LegacyNoteMigratorTests.swift */; };
 		A7000000000000000000007B /* NoteRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000007A /* NoteRepositoryTests.swift */; };
+		A7000000000000000000007D /* TagRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000007C /* TagRepositoryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -162,6 +163,7 @@
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000076 /* LegacyNoteMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigratorTests.swift; sourceTree = "<group>"; };
 		A7000000000000000000007A /* NoteRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRepositoryTests.swift; sourceTree = "<group>"; };
+		A7000000000000000000007C /* TagRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRepositoryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,6 +268,7 @@
 				A70000000000000000000032 /* NoteDataTests.swift */,
 				A70000000000000000000076 /* LegacyNoteMigratorTests.swift */,
 				A7000000000000000000007A /* NoteRepositoryTests.swift */,
+				A7000000000000000000007C /* TagRepositoryTests.swift */,
 				A70000000000000000000007 /* NoteStoreTests.swift */,
 				A70000000000000000000008 /* NoteDocumentTests.swift */,
 				A7000000000000000000000D /* PKDrawingStub.swift */,
@@ -571,6 +574,7 @@
 				A70000000000000000000042 /* NoteDataTests.swift in Sources */,
 				A70000000000000000000077 /* LegacyNoteMigratorTests.swift in Sources */,
 				A7000000000000000000007B /* NoteRepositoryTests.swift in Sources */,
+				A7000000000000000000007D /* TagRepositoryTests.swift in Sources */,
 				A70000000000000000000017 /* NoteStoreTests.swift in Sources */,
 				A70000000000000000000018 /* NoteDocumentTests.swift in Sources */,
 				A7000000000000000000001D /* PKDrawingStub.swift in Sources */,

--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		A6FD03422D3FAD8600224B03 /* NoteListTagHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FD03412D3FAD8600224B03 /* NoteListTagHStack.swift */; };
 		A70000000000000000000011 /* NoteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000001 /* NoteRepository.swift */; };
 		A70000000000000000000061 /* CloudNoteMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000051 /* CloudNoteMonitor.swift */; };
+		A7000000000000000000007F /* TagListCloudMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7000000000000000000007E /* TagListCloudMonitor.swift */; };
 		A70000000000000000000012 /* TagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000002 /* TagRepository.swift */; };
 		A70000000000000000000013 /* PreferenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000003 /* PreferenceRepository.swift */; };
 		A70000000000000000000014 /* NoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000004 /* NoteStore.swift */; };
@@ -160,6 +161,7 @@
 		A7000000000000000000000C /* TagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStoreTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000031 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		A70000000000000000000051 /* CloudNoteMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudNoteMonitor.swift; sourceTree = "<group>"; };
+		A7000000000000000000007E /* TagListCloudMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListCloudMonitor.swift; sourceTree = "<group>"; };
 		A70000000000000000000032 /* NoteDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDataTests.swift; sourceTree = "<group>"; };
 		A70000000000000000000076 /* LegacyNoteMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNoteMigratorTests.swift; sourceTree = "<group>"; };
 		A7000000000000000000007A /* NoteRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRepositoryTests.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 			children = (
 				A70000000000000000000001 /* NoteRepository.swift */,
 				A70000000000000000000051 /* CloudNoteMonitor.swift */,
+				A7000000000000000000007E /* TagListCloudMonitor.swift */,
 				A70000000000000000000002 /* TagRepository.swift */,
 				A70000000000000000000003 /* PreferenceRepository.swift */,
 			);
@@ -618,6 +621,7 @@
 				A6620E36274C7A3D00C708A2 /* NoteListParentView.swift in Sources */,
 				A70000000000000000000011 /* NoteRepository.swift in Sources */,
 				A70000000000000000000061 /* CloudNoteMonitor.swift in Sources */,
+				A7000000000000000000007F /* TagListCloudMonitor.swift in Sources */,
 				A70000000000000000000012 /* TagRepository.swift in Sources */,
 				A70000000000000000000013 /* PreferenceRepository.swift in Sources */,
 				A70000000000000000000014 /* NoteStore.swift in Sources */,

--- a/PiecesOfPaper/Repository/TagListCloudMonitor.swift
+++ b/PiecesOfPaper/Repository/TagListCloudMonitor.swift
@@ -1,0 +1,42 @@
+//
+//  TagListCloudMonitor.swift
+//  PiecesOfPaper
+//
+//  Created by Nakajima on 2026/07/20.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Foundation
+
+/// Watches the iCloud metadata index for taglist.json so the tag list can
+/// reload once an undownloaded copy materializes (fetchAll returns an empty
+/// list until then) or a change synced from another device arrives.
+@MainActor
+final class TagListCloudMonitor {
+    private let query = NSMetadataQuery()
+    private var observers: [NSObjectProtocol] = []
+    var onUpdate: (@MainActor () -> Void)?
+
+    init() {
+        query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+        query.predicate = NSPredicate(format: "%K == %@",
+                                      NSMetadataItemFSNameKey,
+                                      "taglist.json")
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(forName: .NSMetadataQueryDidFinishGathering,
+                                            object: query,
+                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.onUpdate?() }
+        })
+        observers.append(center.addObserver(forName: .NSMetadataQueryDidUpdate,
+                                            object: query,
+                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.onUpdate?() }
+        })
+        query.start()
+    }
+
+    deinit {
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+}

--- a/PiecesOfPaper/Repository/TagRepository.swift
+++ b/PiecesOfPaper/Repository/TagRepository.swift
@@ -14,34 +14,88 @@ protocol TagRepositoryProtocol {
     func saveAll(_ tags: [TagEntity]) -> Bool
 }
 
+/// Where the tag list file stands relative to iCloud download state.
+enum TagListFileState {
+    /// The real file exists locally and can be read.
+    case downloaded
+    /// Only the ".taglist.json.icloud" placeholder exists: the file lives in
+    /// iCloud but has not been downloaded yet.
+    case inCloudOnly
+    /// Neither the file nor a placeholder exists locally.
+    case absent
+
+    static func check(for url: URL, fileManager: FileManager = .default) -> TagListFileState {
+        if fileManager.fileExists(atPath: url.path) {
+            return .downloaded
+        }
+        let placeholderUrl = url.deletingLastPathComponent()
+            .appendingPathComponent("." + url.lastPathComponent + ".icloud")
+        if fileManager.fileExists(atPath: placeholderUrl.path) {
+            return .inCloudOnly
+        }
+        return .absent
+    }
+}
+
 struct TagRepository: TagRepositoryProtocol {
+    // Fixed ids so the in-memory defaults stay identical across launches:
+    // TagEntity equality is id-based and notes embed tag copies, so ids
+    // regenerated per launch would detach notes from their default tags.
     private var defaultTags = [
-        TagEntity(name: "💡idea", color: CodableUIColor(uiColor: .systemYellow)),
-        TagEntity(name: "🗒memo", color: CodableUIColor(uiColor: .systemBlue)),
-        TagEntity(name: "📓note", color: CodableUIColor(uiColor: .systemGreen)),
-        TagEntity(name: "🎨doodle", color: CodableUIColor(uiColor: .systemOrange))
+        TagEntity(id: UUID(uuidString: "1D9C7A80-1E5B-4A61-9F0A-6C39F1A0D001")!,
+                  name: "💡idea", color: CodableUIColor(uiColor: .systemYellow)),
+        TagEntity(id: UUID(uuidString: "1D9C7A80-1E5B-4A61-9F0A-6C39F1A0D002")!,
+                  name: "🗒memo", color: CodableUIColor(uiColor: .systemBlue)),
+        TagEntity(id: UUID(uuidString: "1D9C7A80-1E5B-4A61-9F0A-6C39F1A0D003")!,
+                  name: "📓note", color: CodableUIColor(uiColor: .systemGreen)),
+        TagEntity(id: UUID(uuidString: "1D9C7A80-1E5B-4A61-9F0A-6C39F1A0D004")!,
+                  name: "🎨doodle", color: CodableUIColor(uiColor: .systemOrange))
     ]
 
+    private let tagListFileUrl: URL?
+    private let fileManager: FileManager
+
+    init(tagListFileUrl: URL? = FilePath.tagListFileUrl, fileManager: FileManager = .default) {
+        self.tagListFileUrl = tagListFileUrl
+        self.fileManager = fileManager
+    }
+
+    // Never writes to disk: creating defaults while the iCloud copy is merely
+    // undownloaded would sync them back and wipe the user's tag list (#199).
+    // Defaults are persisted lazily by the first user edit through saveAll.
     func fetchAll() -> [TagEntity] {
-        guard let tagListFileUrl = FilePath.tagListFileUrl else { return [] }
+        guard let tagListFileUrl else { return [] }
         syncFile(url: tagListFileUrl)
 
-        if !FileManager.default.fileExists(atPath: tagListFileUrl.path) {
-            makeFileIfNeeded()
-            return defaultTags
-        } else {
+        switch TagListFileState.check(for: tagListFileUrl, fileManager: fileManager) {
+        case .downloaded:
             return loadTags(from: tagListFileUrl)
+        case .inCloudOnly:
+            return []
+        case .absent:
+            return defaultTags
         }
     }
 
     @discardableResult
     func saveAll(_ tags: [TagEntity]) -> Bool {
-        guard let tagListFileUrl = FilePath.tagListFileUrl else { return false }
+        guard let tagListFileUrl else { return false }
         syncFile(url: tagListFileUrl)
 
+        // Refuse to write over an undownloaded iCloud copy: the caller only
+        // sees the transient empty list, so persisting it would overwrite the
+        // real tag list once the write syncs.
+        guard TagListFileState.check(for: tagListFileUrl, fileManager: fileManager) != .inCloudOnly else {
+            return false
+        }
+
         do {
+            let libraryUrl = tagListFileUrl.deletingLastPathComponent()
+            if !fileManager.fileExists(atPath: libraryUrl.path) {
+                try fileManager.createDirectory(at: libraryUrl, withIntermediateDirectories: true)
+            }
             let data = try JSONEncoder().encode(tags)
-            try data.write(to: tagListFileUrl)
+            try data.write(to: tagListFileUrl, options: .atomic)
             return true
         } catch {
             print(error.localizedDescription)
@@ -50,8 +104,8 @@ struct TagRepository: TagRepositoryProtocol {
     }
 
     private func loadTags(from url: URL) -> [TagEntity] {
-        guard FileManager.default.fileExists(atPath: url.path),
-              let content = FileManager.default.contents(atPath: url.path) else { return [] }
+        guard fileManager.fileExists(atPath: url.path),
+              let content = fileManager.contents(atPath: url.path) else { return [] }
 
         let decoder = JSONDecoder()
         do {
@@ -64,19 +118,9 @@ struct TagRepository: TagRepositoryProtocol {
 
     private func syncFile(url: URL) {
         do {
-            try FileManager.default.startDownloadingUbiquitousItem(at: url)
+            try fileManager.startDownloadingUbiquitousItem(at: url)
         } catch {
             print(error.localizedDescription)
         }
-    }
-
-    private func makeFileIfNeeded() {
-        guard let libraryUrl = FilePath.libraryUrl else { return }
-
-        if !FileManager.default.fileExists(atPath: libraryUrl.path) {
-            try? FileManager.default.createDirectory(at: libraryUrl, withIntermediateDirectories: false)
-        }
-
-        saveAll(defaultTags)
     }
 }

--- a/PiecesOfPaper/Store/TagStore.swift
+++ b/PiecesOfPaper/Store/TagStore.swift
@@ -13,10 +13,15 @@ import Foundation
 final class TagStore {
     private(set) var tags: [TagEntity]
     private let repository: TagRepositoryProtocol
+    @ObservationIgnored private var cloudMonitor: TagListCloudMonitor?
 
     init(repository: TagRepositoryProtocol = TagRepository()) {
         self.repository = repository
         self.tags = repository.fetchAll()
+        if FilePath.isiCloudActive {
+            cloudMonitor = TagListCloudMonitor()
+            cloudMonitor?.onUpdate = { [weak self] in self?.reload() }
+        }
     }
 
     func add(_ tag: TagEntity) {

--- a/PiecesOfPaperTests/TagRepositoryTests.swift
+++ b/PiecesOfPaperTests/TagRepositoryTests.swift
@@ -1,0 +1,142 @@
+//
+//  TagRepositoryTests.swift
+//  PiecesOfPaperTests
+//
+//  Created by Nakajima on 2026/07/20.
+//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Pieces_of_Paper
+
+struct TagRepositoryTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TagRepositoryTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func tagListUrl(in directory: URL) -> URL {
+        directory.appendingPathComponent("Library").appendingPathComponent("taglist.json")
+    }
+
+    private func placeholderUrl(in directory: URL) -> URL {
+        directory.appendingPathComponent("Library").appendingPathComponent(".taglist.json.icloud")
+    }
+
+    private func makeTags() -> [TagEntity] {
+        [TagEntity(name: "work", color: CodableUIColor(uiColor: .systemRed)),
+         TagEntity(name: "home", color: CodableUIColor(uiColor: .systemBlue))]
+    }
+
+    // MARK: - TagListFileState
+
+    @Test func state_isAbsent_whenNeitherFileNorPlaceholderExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(TagListFileState.check(for: tagListUrl(in: directory)) == .absent)
+    }
+
+    @Test func state_isDownloaded_whenFileExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = tagListUrl(in: directory)
+        try FileManager.default.createDirectory(at: fileUrl.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try JSONEncoder().encode(makeTags()).write(to: fileUrl)
+
+        #expect(TagListFileState.check(for: fileUrl) == .downloaded)
+    }
+
+    @Test func state_isInCloudOnly_whenOnlyPlaceholderExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let placeholder = placeholderUrl(in: directory)
+        try FileManager.default.createDirectory(at: placeholder.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data().write(to: placeholder)
+
+        #expect(TagListFileState.check(for: tagListUrl(in: directory)) == .inCloudOnly)
+    }
+
+    // MARK: - fetchAll
+
+    @Test func fetchAll_loadsTags_whenFileExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = tagListUrl(in: directory)
+        try FileManager.default.createDirectory(at: fileUrl.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        let tags = makeTags()
+        try JSONEncoder().encode(tags).write(to: fileUrl)
+
+        #expect(TagRepository(tagListFileUrl: fileUrl).fetchAll() == tags)
+    }
+
+    // Regression test for #199: an undownloaded iCloud copy must be treated as
+    // "still downloading", not "missing" — no defaults returned, nothing written.
+    @Test func fetchAll_returnsEmptyAndWritesNothing_whenOnlyPlaceholderExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let placeholder = placeholderUrl(in: directory)
+        try FileManager.default.createDirectory(at: placeholder.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data().write(to: placeholder)
+        let fileUrl = tagListUrl(in: directory)
+
+        #expect(TagRepository(tagListFileUrl: fileUrl).fetchAll() == [])
+        #expect(!FileManager.default.fileExists(atPath: fileUrl.path))
+    }
+
+    @Test func fetchAll_returnsDefaultsWithoutCreatingFile_whenAbsent() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = tagListUrl(in: directory)
+
+        let tags = TagRepository(tagListFileUrl: fileUrl).fetchAll()
+
+        #expect(tags.count == 4)
+        #expect(!FileManager.default.fileExists(atPath: fileUrl.path))
+    }
+
+    @Test func fetchAll_returnsStableDefaultIds_acrossInstances() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = tagListUrl(in: directory)
+
+        let first = TagRepository(tagListFileUrl: fileUrl).fetchAll()
+        let second = TagRepository(tagListFileUrl: fileUrl).fetchAll()
+
+        #expect(first.map(\.id) == second.map(\.id))
+    }
+
+    // MARK: - saveAll
+
+    @Test func saveAll_refusesToWrite_whenOnlyPlaceholderExists() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let placeholder = placeholderUrl(in: directory)
+        try FileManager.default.createDirectory(at: placeholder.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data().write(to: placeholder)
+        let fileUrl = tagListUrl(in: directory)
+
+        #expect(!TagRepository(tagListFileUrl: fileUrl).saveAll(makeTags()))
+        #expect(!FileManager.default.fileExists(atPath: fileUrl.path))
+        #expect(FileManager.default.fileExists(atPath: placeholder.path))
+    }
+
+    @Test func saveAll_createsLibraryDirectoryAndRoundTrips() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileUrl = tagListUrl(in: directory)
+        let repository = TagRepository(tagListFileUrl: fileUrl)
+        let tags = makeTags()
+
+        #expect(repository.saveAll(tags))
+        #expect(repository.fetchAll() == tags)
+    }
+}

--- a/docs/progress/2026-07-20-taglist-icloud-placeholder.md
+++ b/docs/progress/2026-07-20-taglist-icloud-placeholder.md
@@ -1,0 +1,6 @@
+- [x] Stop `TagRepository.fetchAll` from overwriting the tag list with defaults while the iCloud copy is undownloaded (issue #199, PR #209)
+  - `TagListFileState` distinguishes downloaded / in-cloud-only (`.taglist.json.icloud` placeholder) / absent; fetch never writes to disk
+  - Defaults get fixed UUIDs and are persisted lazily on the first user edit (id-based `TagEntity` equality would otherwise detach notes from default tags)
+  - `saveAll` refuses to write over an undownloaded placeholder, writes `.atomic`, and owns Library-directory creation
+  - `TagListCloudMonitor` (NSMetadataQuery on `taglist.json`) reloads `TagStore` when the download lands or another device edits tags
+  - Prerequisite for tag-model normalization (#203); residual fresh-install race documented in the PR


### PR DESCRIPTION
Closes #199

## Problem

`TagRepository.fetchAll()` treated an undownloaded iCloud copy of `taglist.json` as a missing file: `startDownloadingUbiquitousItem` is fire-and-forget, so on a fresh device or offline start the `fileExists` check saw only the `.taglist.json.icloud` placeholder, wrote the 4 default tags to disk, and that write synced back to iCloud — replacing the user's real tag list on every device. `saveAll` also wrote without `.atomic`, so a crash mid-write could corrupt the file. #199 is a prerequisite for the tag-model normalization (#203), where `taglist.json` becomes the single source of truth.

## Fix

**`fetchAll` no longer writes to disk, ever.** A new `TagListFileState` check distinguishes three states of the tag list file:

- `.downloaded` — real file exists → load it (unchanged)
- `.inCloudOnly` — only the `.taglist.json.icloud` placeholder exists → trigger the download and return `[]`; a new `TagListCloudMonitor` (`NSMetadataQuery` scoped to `taglist.json`, modeled on `CloudNoteMonitor`) reloads `TagStore` the moment the file materializes, so the tags appear without user navigation. The monitor also picks up tag edits synced from other devices.
- `.absent` — neither exists → return the defaults **in memory only**; they are persisted lazily by the first user edit through `saveAll`.

Supporting changes:

- **Default tags now have fixed UUIDs.** `TagEntity` equality is id-based and notes embed tag copies, so defaults regenerated with fresh UUIDs each launch would detach notes from their default tags once the eager write was removed. Existing users are unaffected (their ids are already persisted in `taglist.json`).
- **`saveAll` refuses to write in the `.inCloudOnly` state** (returns `false`; `TagStore.saveOrRollback` already rolls the UI back). This closes the write-path variant of the same bug: adding a tag while the list transiently shows `[]` would otherwise persist `[newTag]` over the cloud copy.
- **`saveAll` writes with `.atomic`** and takes over Library-directory creation (`makeFileIfNeeded` is deleted).
- `TagRepository` gains injectable `tagListFileUrl`/`fileManager` (same seam as `LegacyNoteMigrator`) so the real repository is unit-testable against a temp directory. `TagRepositoryProtocol` is unchanged.

## Why not a coordinated read (the #192 approach)

`NSFileCoordinator`/`UIDocument`-style coordinated reads block until the download completes. `fetchAll` runs synchronously on the MainActor at app start; offline, a coordinated read would hang launch indefinitely. Returning `[]` and reloading on the metadata-query signal keeps startup non-blocking while never destroying data.

## Residual risk (accepted, documented for #203)

On a fresh install, before iCloud metadata sync delivers the placeholder, the state reads `.absent`. Since fetch never writes, this window is non-destructive; defaults would only be persisted if the user edits tags inside that window, and that write surfaces as an iCloud conflict version rather than a silent default overwrite.

## Tests

New `TagRepositoryTests` (9 tests, real repository against a temp dir): the three `TagListFileState` states, the #199 regression (placeholder → `[]` and nothing written), defaults returned without creating a file, stable default ids across instances, `saveAll` refusing to write over a placeholder, and directory-creating round-trip.

## Verification

- Full suite on iOS Simulator after a clean build (pbxproj touched): 59 tests / 8 suites green.
- Physical-device check before merge (per issue): fresh install signed into iCloud with an existing tag list → tags must appear (possibly after a brief empty state), not reset to defaults.
