### PR TITLE
docs: document fragment PR-number ordering

### DIFF
--- a/docs/progress/2026-07-20-fragment-pr-number-ordering.md
+++ b/docs/progress/2026-07-20-fragment-pr-number-ordering.md
@@ -1,0 +1,2 @@
+- [x] Document fragment PR-number ordering in docs/progress/README.md (issue #214, PR #215)
+  - Push code commits first, create the PR, then commit the fragment with the number from the `gh pr create` output URL

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -8,6 +8,9 @@ appending to PROGRESS.md directly, so parallel PRs never conflict on the same fi
 
 - File name: `YYYY-MM-DD-<slug>.md` — the date is the work date, the slug is a short identifier such as the branch name.
 - Body: bullet list only, same format as the Work Log. No headings (`#`).
+- The PR number is not known until the PR exists: push the code commits first, create
+  the PR, then commit the fragment with the number taken from the `gh pr create`
+  output URL. Never guess the next number.
 
 ```markdown
 - [x] Add some feature (issue #N, PR #M)


### PR DESCRIPTION
Closes #214

The fragment format includes the PR number, but the number does not exist until the PR is created. This documents the safe ordering in docs/progress/README.md: push the code commits first, create the PR, then commit the fragment with the number taken from the `gh pr create` output URL — never guess the next number.

Docs-only change; no logic touched. The fragment for this PR follows the documented ordering (added in a follow-up commit with the real number).