### PR TITLE
Document UIDocument open-failure pitfalls, presentation environment inheritance, and simctl openurl

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -12,10 +12,13 @@ Each entry links to the issue/PR where the details live.
 ## iCloud / UIDocument
 
 - **`NoteDocument`'s conflict resolution is not unit-testable on iOS**: `NSFileVersion.addOfItem(at:withContentsOf:)` — the only API that fabricates file versions — is macOS-only, so iOS tests cannot create conflicting versions locally. Verify conflict handling with two devices syncing over real iCloud. Background: issue #196, PR #197.
+- **Never `close()` a `UIDocument` whose `open()` failed**: the close completion handler is never invoked for a document that never opened, so the caller awaits forever. `NoteRepository.open` closes only after a successful open. Symptom that found it: the test runner printed "Restarting after unexpected exit, crash, or test timeout" with **no crash report (.ips) and a minutes-long gap** — a hang, not a crash. Trace how far the document got with `xcrun simctl spawn <udid> log show --predicate 'eventMessage CONTAINS "<file>"'` (UIDocumentLog logs every phase). Background: issue #198, PR #208.
+- **`UIDocument.open()` on a missing file waits forever by design**: the coordinated read treats it as an undownloaded iCloud item and waits for the download. Don't write a "missing file throws" test — use a corrupt file to exercise the failure path. Background: PR #208.
 
 ## SwiftUI
 
 - **Alerts attached below a `fullScreenCover` never show while the cover is up**: `NoteListParentView` has `.alert(isPresented: $noteStore.showAlert)`, but while `CanvasView` is presented via `.fullScreenCover`, that alert is not displayed. Do not refactor cover-side errors onto the store's `showAlert`/`alertType` pattern — errors shown on top of a cover must live in a view-local `@State` + `.alert` inside the cover. The store alert pattern is for the list screens only. Background: PR #186 review.
+- **`fullScreenCover`/`sheet` content only inherits environment values injected *outside* the modifier's attachment point**: attaching a cover after `.environment(store)` in the chain (i.e. outside it) crashes at presentation with "No Observable object of type NoteStore found". Attach presentation modifiers *inside* the `.environment` chain — `SideBarListView` does this deliberately. Background: PR #208.
 
 ## Xcode / build
 

--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -68,6 +68,17 @@ Verified example: two swipes (`100 300 300 500`, `300 500 150 650`), then `descr
 returned two "Pen, black" elements with matching frames and a new plist appeared in
 InboxFolder.
 
+## Opening a note file via URL (onOpenURL path)
+
+```sh
+xcrun simctl openurl $UDID "file://$(xcrun simctl get_app_container $UDID Individual.LikeAPaper data)/Documents/InboxFolder/<note>.pop"
+```
+
+delivers the file URL to the app's `onOpenURL` handler — both while the app is running
+(canvas swap) and from a cold launch — without automating the Files app. It cannot
+exercise the security-scope path (files outside the app container); that still needs a
+device and the real Files app. Background: PR #208.
+
 ## Limitations
 
 - **No multi-touch**: idb's HID surface is single-touch (`multi-tap` is sequential taps at

--- a/docs/progress/2026-07-20-gotchas-uidocument-open.md
+++ b/docs/progress/2026-07-20-gotchas-uidocument-open.md
@@ -1,4 +1,4 @@
-- [x] Document pitfalls surfaced by the Files-app open work (issue #217)
+- [x] Document pitfalls surfaced by the Files-app open work (issue #217, PR #218)
   - GOTCHAS: `UIDocument.close()` after a failed `open()` hangs forever; `open()` on a missing file waits for an iCloud download by design (test the failure path with a corrupt file); a test-runner "Restarting" line with no `.ips` and a minutes-long gap is a hang, traceable via UIDocumentLog
   - GOTCHAS: `fullScreenCover`/`sheet` content only inherits environment values injected outside the attachment point — attach presentation modifiers inside the `.environment` chain
   - SIMULATOR_E2E: `simctl openurl` with a `file://` URL exercises the `onOpenURL` document-open path without automating the Files app

--- a/docs/progress/2026-07-20-gotchas-uidocument-open.md
+++ b/docs/progress/2026-07-20-gotchas-uidocument-open.md
@@ -1,0 +1,4 @@
+- [x] Document pitfalls surfaced by the Files-app open work (issue #217)
+  - GOTCHAS: `UIDocument.close()` after a failed `open()` hangs forever; `open()` on a missing file waits for an iCloud download by design (test the failure path with a corrupt file); a test-runner "Restarting" line with no `.ips` and a minutes-long gap is a hang, traceable via UIDocumentLog
+  - GOTCHAS: `fullScreenCover`/`sheet` content only inherits environment values injected outside the attachment point — attach presentation modifiers inside the `.environment` chain
+  - SIMULATOR_E2E: `simctl openurl` with a `file://` URL exercises the `onOpenURL` document-open path without automating the Files app


### PR DESCRIPTION
Closes #217

3 files changed, +18 (docs only, no logic changes)

① **docs/GOTCHAS.md — iCloud / UIDocument**: two new entries — `close()` after a failed `open()` never fires its completion handler (permanent hang; fixed in PR #208, recorded here so the pattern is not reintroduced), and `open()` on a missing file waits forever by design (use a corrupt file to test the failure path). Includes the hang-vs-crash diagnosis pattern (no `.ips` + minutes-long gap ⇒ hang; trace via UIDocumentLog).
② **docs/GOTCHAS.md — SwiftUI**: presentation content only inherits environment values injected outside the modifier's attachment point; attach covers inside the `.environment` chain.
③ **docs/SIMULATOR_E2E.md**: `simctl openurl` with a `file://` URL exercises the `onOpenURL` document-open path without automating the Files app (security-scope path still needs a device).

Plus the progress fragment per the repo workflow.