### PR TITLE
Remove Xcode default file headers and enforce with SwiftLint

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Revisions to skip in `git blame` (GitHub honors this file automatically;
+# locally: git config blame.ignoreRevsFile .git-blame-ignore-revs)
+
+# Remove Xcode default file headers from all Swift files
+bc9d71a738b98617f6ccafc611763db1b146bb2a

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -110,7 +110,7 @@ opt_in_rules:
   #- extension_access_modifier # このルールの意味を理解していないため
   - fallthrough
   # - fatal_error_message # メッセージは不要なため
-  #- file_header # このルールの意味を理解していないため
+  - file_header
   - file_name
   - first_where
   - force_unwrapping
@@ -185,6 +185,9 @@ excluded:
   - Carthage
   - SourcePackages
   - Generated
+
+file_header:
+  forbidden_pattern: "\\bCopyright\\b|Created by .+ on \\d{4}/\\d{2}/\\d{2}"
 
 line_length:
   warning: 300

--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -1,11 +1,3 @@
-//
-//  FilePath.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/11/23.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 enum FilePath {

--- a/PiecesOfPaper/Model/LegacyNoteMigrator.swift
+++ b/PiecesOfPaper/Model/LegacyNoteMigrator.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyNoteMigrator.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 /// Renames legacy `.plist` notes to the current note file extension.

--- a/PiecesOfPaper/Model/ListOrder.swift
+++ b/PiecesOfPaper/Model/ListOrder.swift
@@ -1,11 +1,3 @@
-//
-//  ListOrder.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/11.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 struct ListOrder: Codable {

--- a/PiecesOfPaper/Model/NoteData.swift
+++ b/PiecesOfPaper/Model/NoteData.swift
@@ -1,11 +1,3 @@
-//
-//  NoteData.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/18.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import PencilKit
 

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -1,11 +1,3 @@
-//
-//  NoteDocument.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/11/23.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import PencilKit
 

--- a/PiecesOfPaper/Model/NoteEntity.swift
+++ b/PiecesOfPaper/Model/NoteEntity.swift
@@ -1,11 +1,3 @@
-//
-//  NoteEntity.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/04.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import PencilKit
 

--- a/PiecesOfPaper/Model/NoteIndexEntry.swift
+++ b/PiecesOfPaper/Model/NoteIndexEntry.swift
@@ -1,11 +1,3 @@
-//
-//  NoteIndexEntry.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 /// Listing metadata learned from a document open. Valid while its updatedDate

--- a/PiecesOfPaper/Model/TagEntity.swift
+++ b/PiecesOfPaper/Model/TagEntity.swift
@@ -1,11 +1,3 @@
-//
-//  TagEntity.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/05.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import SwiftUI
 

--- a/PiecesOfPaper/PiecesOfPaperApp.swift
+++ b/PiecesOfPaper/PiecesOfPaperApp.swift
@@ -1,11 +1,3 @@
-//
-//  PiecesOfPaperApp.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/11/03.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 import PencilKit
 

--- a/PiecesOfPaper/Repository/CloudNoteMonitor.swift
+++ b/PiecesOfPaper/Repository/CloudNoteMonitor.swift
@@ -1,11 +1,3 @@
-//
-//  CloudNoteMonitor.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 struct CloudNoteItem: Equatable {

--- a/PiecesOfPaper/Repository/NoteRepository.swift
+++ b/PiecesOfPaper/Repository/NoteRepository.swift
@@ -1,11 +1,3 @@
-//
-//  NoteRepository.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2025/01/26.
-//  Copyright © 2025 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 
 enum NoteDirectory: String {

--- a/PiecesOfPaper/Repository/PreferenceRepository.swift
+++ b/PiecesOfPaper/Repository/PreferenceRepository.swift
@@ -1,11 +1,3 @@
-//
-//  PreferenceRepository.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/13.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 protocol PreferenceRepositoryProtocol {

--- a/PiecesOfPaper/Repository/TagListCloudMonitor.swift
+++ b/PiecesOfPaper/Repository/TagListCloudMonitor.swift
@@ -1,11 +1,3 @@
-//
-//  TagListCloudMonitor.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 /// Watches the iCloud metadata index for taglist.json so the tag list can

--- a/PiecesOfPaper/Repository/TagRepository.swift
+++ b/PiecesOfPaper/Repository/TagRepository.swift
@@ -1,11 +1,3 @@
-//
-//  TagRepository.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/05.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 protocol TagRepositoryProtocol {

--- a/PiecesOfPaper/RootView.swift
+++ b/PiecesOfPaper/RootView.swift
@@ -1,11 +1,3 @@
-//
-//  RootView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2022/02/24.
-//  Copyright © 2022 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct RootView: View {

--- a/PiecesOfPaper/SideBarListView.swift
+++ b/PiecesOfPaper/SideBarListView.swift
@@ -1,11 +1,3 @@
-//
-//  SideBarListView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/11/03.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct SideBarListView: View {

--- a/PiecesOfPaper/Store/NoteStore+Loading.swift
+++ b/PiecesOfPaper/Store/NoteStore+Loading.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStore+Loading.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 // MARK: - Display ordering

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStore.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/11/03.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import PencilKit
 

--- a/PiecesOfPaper/Store/NoteStoreError.swift
+++ b/PiecesOfPaper/Store/NoteStoreError.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStoreError.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 enum NoteStoreError: LocalizedError {

--- a/PiecesOfPaper/Store/PreferenceStore.swift
+++ b/PiecesOfPaper/Store/PreferenceStore.swift
@@ -1,11 +1,3 @@
-//
-//  PreferenceStore.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/13.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 @Observable

--- a/PiecesOfPaper/Store/TagStore.swift
+++ b/PiecesOfPaper/Store/TagStore.swift
@@ -1,11 +1,3 @@
-//
-//  TagStore.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/05.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 
 @Observable

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -1,11 +1,3 @@
-//
-//  CanvasView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/10/29.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 import PencilKit
 import StoreKit

--- a/PiecesOfPaper/View/Canvas/NoteInformationView.swift
+++ b/PiecesOfPaper/View/Canvas/NoteInformationView.swift
@@ -1,11 +1,3 @@
-//
-//  NoteInformation.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/12.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct NoteInformationView: View {

--- a/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
@@ -1,11 +1,3 @@
-//
-//  PKCanvasViewWrapper.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/10/29.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 import PencilKit
 

--- a/PiecesOfPaper/View/Canvas/UIActivityViewControllerWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/UIActivityViewControllerWrapper.swift
@@ -1,11 +1,3 @@
-//
-//  UIActivityViewControllerWrapper.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/10/30.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import SwiftUI
 import LinkPresentation

--- a/PiecesOfPaper/View/NoteList/ListOrderSettingView.swift
+++ b/PiecesOfPaper/View/NoteList/ListOrderSettingView.swift
@@ -1,11 +1,3 @@
-//
-//  ListOrderSettingView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/11.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct ListOrderSettingView: View {

--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -1,11 +1,3 @@
-//
-//  NoteListParentView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/10/31.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 import PencilKit
 

--- a/PiecesOfPaper/View/NoteList/NoteListView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListView.swift
@@ -1,11 +1,3 @@
-//
-//  NoteListView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/10/31.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct NoteListView: View {

--- a/PiecesOfPaper/View/NoteList/NoteView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteView.swift
@@ -1,11 +1,3 @@
-//
-//  NoteView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/03.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 import PencilKit
 

--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -1,11 +1,3 @@
-//
-//  ThumbnailCache.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2026/07/11.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import PencilKit
 

--- a/PiecesOfPaper/View/Setting/SettingView.swift
+++ b/PiecesOfPaper/View/Setting/SettingView.swift
@@ -1,11 +1,3 @@
-//
-//  SettingView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/13.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct SettingView: View {

--- a/PiecesOfPaper/View/Tag/AddTagFooter.swift
+++ b/PiecesOfPaper/View/Tag/AddTagFooter.swift
@@ -1,11 +1,3 @@
-//
-//  AddTagFooter.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/06.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct AddTagFooter: View {

--- a/PiecesOfPaper/View/Tag/AddTagView.swift
+++ b/PiecesOfPaper/View/Tag/AddTagView.swift
@@ -1,11 +1,3 @@
-//
-//  AddTagView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/05.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct AddTagView: View {

--- a/PiecesOfPaper/View/Tag/DeletableTag.swift
+++ b/PiecesOfPaper/View/Tag/DeletableTag.swift
@@ -1,11 +1,3 @@
-//
-//  DeletableTag.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/06.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct DeletableTag: View {

--- a/PiecesOfPaper/View/Tag/NoteListTagHStack.swift
+++ b/PiecesOfPaper/View/Tag/NoteListTagHStack.swift
@@ -1,11 +1,3 @@
-//
-//  TagHStack.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/06.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct NoteListTagHStack: View {

--- a/PiecesOfPaper/View/Tag/Tag.swift
+++ b/PiecesOfPaper/View/Tag/Tag.swift
@@ -1,11 +1,3 @@
-//
-//  Tag.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/06.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct Tag: View {

--- a/PiecesOfPaper/View/Tag/TagHStack.swift
+++ b/PiecesOfPaper/View/Tag/TagHStack.swift
@@ -1,11 +1,3 @@
-//
-//  TagHStack.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/06.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct TagHStack: View {

--- a/PiecesOfPaper/View/Tag/TagList.swift
+++ b/PiecesOfPaper/View/Tag/TagList.swift
@@ -1,11 +1,3 @@
-//
-//  TagList.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2021/12/05.
-//  Copyright © 2021 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct TagList: View {

--- a/PiecesOfPaper/View/Tutorial/TutorialView.swift
+++ b/PiecesOfPaper/View/Tutorial/TutorialView.swift
@@ -1,11 +1,3 @@
-//
-//  TutorialView.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2025/01/26.
-//  Copyright © 2025 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import SwiftUI
 
 struct TutorialView: View {

--- a/PiecesOfPaperTests/FilePathTests.swift
+++ b/PiecesOfPaperTests/FilePathTests.swift
@@ -1,11 +1,3 @@
-//
-//  FilePathTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Testing
 import Foundation
 @testable import Pieces_of_Paper

--- a/PiecesOfPaperTests/LegacyNoteMigratorTests.swift
+++ b/PiecesOfPaperTests/LegacyNoteMigratorTests.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyNoteMigratorTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Testing
 import Foundation
 @testable import Pieces_of_Paper

--- a/PiecesOfPaperTests/NoteDataTests.swift
+++ b/PiecesOfPaperTests/NoteDataTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteDataTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/18.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import Testing
 import PencilKit

--- a/PiecesOfPaperTests/NoteDocumentTests.swift
+++ b/PiecesOfPaperTests/NoteDocumentTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteDocumentTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/11.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import Testing
 import PencilKit

--- a/PiecesOfPaperTests/NoteIndexEntryTests.swift
+++ b/PiecesOfPaperTests/NoteIndexEntryTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteIndexEntryTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import Testing
 @testable import Pieces_of_Paper

--- a/PiecesOfPaperTests/NoteRepositoryTests.swift
+++ b/PiecesOfPaperTests/NoteRepositoryTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteRepositoryTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Testing
 import Foundation
 import PencilKit

--- a/PiecesOfPaperTests/NoteStoreCanvasPresentationTests.swift
+++ b/PiecesOfPaperTests/NoteStoreCanvasPresentationTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStoreCanvasPresentationTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import Testing
 import PencilKit

--- a/PiecesOfPaperTests/NoteStoreFilterHydrationTests.swift
+++ b/PiecesOfPaperTests/NoteStoreFilterHydrationTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStoreFilterHydrationTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import Testing
 import PencilKit

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoteStoreTests.swift
-//  PiecesOfPaper
-//
-//  Created by Nakajima on 2022/05/28.
-//  Copyright © 2022 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import Testing
 import PencilKit

--- a/PiecesOfPaperTests/PKDrawingStub.swift
+++ b/PiecesOfPaperTests/PKDrawingStub.swift
@@ -1,11 +1,3 @@
-//
-//  PKDrawingStub.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import PencilKit
 
 extension PKDrawing {

--- a/PiecesOfPaperTests/PreferenceStoreTests.swift
+++ b/PiecesOfPaperTests/PreferenceStoreTests.swift
@@ -1,11 +1,3 @@
-//
-//  PreferenceStoreTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/18.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Testing
 @testable import Pieces_of_Paper
 

--- a/PiecesOfPaperTests/RepositoryMocks.swift
+++ b/PiecesOfPaperTests/RepositoryMocks.swift
@@ -1,11 +1,3 @@
-//
-//  RepositoryMocks.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Foundation
 import PencilKit
 @testable import Pieces_of_Paper

--- a/PiecesOfPaperTests/TagRepositoryTests.swift
+++ b/PiecesOfPaperTests/TagRepositoryTests.swift
@@ -1,11 +1,3 @@
-//
-//  TagRepositoryTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/20.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import Testing
 import Foundation
 @testable import Pieces_of_Paper

--- a/PiecesOfPaperTests/TagStoreTests.swift
+++ b/PiecesOfPaperTests/TagStoreTests.swift
@@ -1,11 +1,3 @@
-//
-//  TagStoreTests.swift
-//  PiecesOfPaperTests
-//
-//  Created by Nakajima on 2026/07/18.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import Testing
 @testable import Pieces_of_Paper

--- a/PreviewExtension/PreviewProvider.swift
+++ b/PreviewExtension/PreviewProvider.swift
@@ -1,11 +1,3 @@
-//
-//  PreviewProvider.swift
-//  PreviewExtension
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import QuickLook
 import PencilKit

--- a/ThumbnailExtension/ThumbnailProvider.swift
+++ b/ThumbnailExtension/ThumbnailProvider.swift
@@ -1,11 +1,3 @@
-//
-//  ThumbnailProvider.swift
-//  ThumbnailExtension
-//
-//  Created by Nakajima on 2026/07/19.
-//  Copyright © 2026 Tsuyoshi Nakajima. All rights reserved.
-//
-
 import UIKit
 import QuickLookThumbnailing
 import PencilKit

--- a/docs/progress/2026-07-20-remove-xcode-file-headers.md
+++ b/docs/progress/2026-07-20-remove-xcode-file-headers.md
@@ -1,0 +1,4 @@
+- [x] Remove the Xcode default file headers from all Swift files and ban them via SwiftLint (issue #223, PR #228)
+  - `file_header` is not a correctable rule, so `swiftlint --fix` cannot strip the headers; the 55 files were stripped with a one-off script after verifying every one matched the template exactly
+  - `.git-blame-ignore-revs` added so the 55-file removal commit does not obscure `git blame`
+  - `PreviewExtension` / `ThumbnailExtension` are outside `.swiftlint.yml`'s `included:`, so their headers are removed but not enforced


### PR DESCRIPTION
## Summary

Removes the Xcode default file header from every Swift file and enables the SwiftLint `file_header` rule so the headers cannot come back.

Closes #223

## Changes

1. **Remove headers (55 files, 440 deletions, 0 insertions).** Every tracked Swift file except `scripts/consolidate-progress.swift` carried the exact same 7-line template followed by a blank line; all 55 were verified against that shape before stripping, so the diff is deletion-only. `scripts/consolidate-progress.swift` is untouched — its leading comment is real documentation, not the Xcode template.
2. **`.swiftlint.yml`**: enable the opt-in `file_header` rule with `forbidden_pattern: "\\bCopyright\\b|Created by .+ on \\d{4}/\\d{2}/\\d{2}"`, matching both the `Created by` and `Copyright ©` lines of the template. Severity is left at the default (warning), consistent with the other rules here.
3. **`.git-blame-ignore-revs`**: a one-file change touching 55 files ruins `git blame`, so the removal commit is listed here. GitHub honors the file automatically; locally it needs `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## Note on the issue's approach

Step 2 of the issue (`swiftlint --fix` auto-removes the headers) does not work: `swiftlint rules` reports `file_header` as **not correctable**, and running `swiftlint --fix` after enabling the rule changes nothing. The removal was done with a one-off script instead (not committed).

## Scope

`PreviewExtension` / `ThumbnailExtension` are outside `.swiftlint.yml`'s `included:` list. Their headers are removed, but the rule does not cover them; adding those directories to `included:` would surface unrelated violations and is left out of this PR.

## Verification

- `swiftlint lint` — no `file_header` violations; the pre-existing 6 warnings (4 `force_unwrapping`, 2 `file_name`) are unchanged.
- Rule actually fires: temporarily re-added the template to `NoteView.swift` → `File Header Violation ... (file_header)`, then reverted.
- `xcodebuild ... test` on iPad Pro 11-inch (M5): **TEST SUCCEEDED**, 103 tests in 14 suites passed.
- `git blame --ignore-revs-file .git-blame-ignore-revs` on a stripped file attributes line 1 to the original authoring commits, not the removal commit.

No canvas / PencilKit logic is touched, so no device verification is required.
