### PR TITLE
Make the empty note list refreshable with pull-to-refresh

### DIFF
--- a/PiecesOfPaper/View/NoteList/NoteListParentView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListParentView.swift
@@ -29,12 +29,11 @@ struct NoteListParentView: View {
             } else {
                 if noteStore.displayEntries(for: directory).isEmpty {
                     // While a tag filter hydrates, nothing may match yet;
-                    // "No Data" would be premature
+                    // the empty state would be premature
                     if noteStore.isFilterHydrating(for: directory) {
                         ProgressView()
                     } else {
-                        Text("No Data")
-                            .font(.largeTitle)
+                        emptyStateView
                     }
                 } else {
                     NoteScrollView(directory: directory)
@@ -112,6 +111,19 @@ struct NoteListParentView: View {
             default:
                 break
             }
+        }
+    }
+
+    // Not a bare ContentUnavailableView: `.refreshable` only exposes the
+    // pull-to-refresh gesture inside a scrollable container
+    private var emptyStateView: some View {
+        ScrollView {
+            ContentUnavailableView(
+                "No Notes",
+                systemImage: "note.text",
+                description: Text("Pull down to refresh.")
+            )
+            .containerRelativeFrame(.vertical)
         }
     }
 

--- a/docs/progress/2026-07-20-empty-state-refreshable.md
+++ b/docs/progress/2026-07-20-empty-state-refreshable.md
@@ -1,0 +1,3 @@
+- [x] Make the empty note list refreshable with pull-to-refresh (issue #213, PR #229)
+  - `Text("No Data")` → `ContentUnavailableView` inside a `ScrollView`; `.refreshable` only exposes the gesture in a scrollable container
+  - Verified with idb: dropping a `.pop` into `InboxFolder` while the empty state is on screen, then pulling down, loads it


### PR DESCRIPTION
## Summary

The empty note list rendered a bare `Text("No Data")`. `.refreshable` is attached to the
enclosing `Group`, but SwiftUI only exposes the pull-to-refresh gesture inside a scrollable
container, so the empty state could not be refreshed — in local-storage mode the ellipsis
menu's "Reload" was the only way out.

The empty state is now a `ContentUnavailableView` wrapped in a `ScrollView`, sized to the
container with `containerRelativeFrame(.vertical)` so it stays vertically centered. Pull-to-refresh
runs the existing `noteStore.fetch(directory:background:)`; no store or reload logic changed.

## Verification

- Simulator (iPad Pro 11-inch, iOS 26.3), iCloud disabled, empty inbox: the empty state renders
  centered, and an `idb ui swipe` pull loads a `.pop` file that was dropped into `InboxFolder`
  while the empty state was on screen — i.e. the gesture reaches `.refreshable`.
- `xcodebuild test`: 103 tests in 14 suites passed.
- No PencilKit / canvas rendering code is touched, so no device verification is required.

Closes #213
