### PR TITLE
Improve accessibility labels, error visibility, and logging

### DIFF
--- a/PiecesOfPaper/Model/FilePath.swift
+++ b/PiecesOfPaper/Model/FilePath.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 enum FilePath {
     static var savingUrl: URL? {
@@ -75,11 +76,24 @@ enum FilePath {
     static func makeDirectoryIfNeeded() {
         guard let inboxUrl = FilePath.inboxUrl, let archivedUrl = FilePath.archivedUrl else { return }
         if !FileManager.default.fileExists(atPath: inboxUrl.path) {
-            try? FileManager.default.createDirectory(at: inboxUrl, withIntermediateDirectories: false)
+            createDirectory(at: inboxUrl)
         }
 
         if !FileManager.default.fileExists(atPath: archivedUrl.path) {
-            try? FileManager.default.createDirectory(at: archivedUrl, withIntermediateDirectories: false)
+            createDirectory(at: archivedUrl)
+        }
+    }
+
+    // Intermediate directories stay off: the parent is the system-provided
+    // Documents directory, so a missing parent should surface in the log
+    // instead of being silently created
+    private static func createDirectory(at url: URL) {
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        } catch {
+            Logger.filePath.error(
+                "Failed to create directory at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 }

--- a/PiecesOfPaper/Model/Logger+App.swift
+++ b/PiecesOfPaper/Model/Logger+App.swift
@@ -1,0 +1,12 @@
+import os
+
+extension Logger {
+    // Hardcoded rather than Bundle.main.bundleIdentifier: this file is compiled
+    // into the app target only, and a constant keeps the Console filter greppable
+    private static let subsystem = "Individual.LikeAPaper"
+
+    static let tagRepository = Logger(subsystem: subsystem, category: "TagRepository")
+    static let noteMetadataCache = Logger(subsystem: subsystem, category: "NoteMetadataCache")
+    static let noteDocument = Logger(subsystem: subsystem, category: "NoteDocument")
+    static let filePath = Logger(subsystem: subsystem, category: "FilePath")
+}

--- a/PiecesOfPaper/Model/NoteDocument.swift
+++ b/PiecesOfPaper/Model/NoteDocument.swift
@@ -1,5 +1,6 @@
 import UIKit
 import PencilKit
+import os
 
 final class NoteDocument: UIDocument {
     var entity: NoteEntity
@@ -60,7 +61,9 @@ final class NoteDocument: UIDocument {
             try NSFileVersion.removeOtherVersionsOfItem(at: fileURL)
             conflictVersions.forEach { $0.isResolved = true }
         } catch {
-            print("failed to resolve conflict versions: ", error.localizedDescription)
+            Logger.noteDocument.error(
+                "Failed to resolve conflict versions: \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 

--- a/PiecesOfPaper/Repository/NoteMetadataCacheRepository.swift
+++ b/PiecesOfPaper/Repository/NoteMetadataCacheRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 protocol NoteMetadataCacheRepositoryProtocol: Sendable {
     /// Keyed by file name; see NoteIndexEntry.fileName
@@ -41,7 +42,9 @@ struct NoteMetadataCacheRepository: NoteMetadataCacheRepositoryProtocol {
             let data = try JSONEncoder().encode(file)
             try data.write(to: fileUrl, options: .atomic)
         } catch {
-            print("Could not write the note metadata cache: ", error.localizedDescription)
+            Logger.noteMetadataCache.error(
+                "Could not write the note metadata cache: \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 }

--- a/PiecesOfPaper/Repository/TagRepository.swift
+++ b/PiecesOfPaper/Repository/TagRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 protocol TagRepositoryProtocol {
     // Coordination happens off the main actor inside CoordinatedFileAccess, so
@@ -83,7 +84,7 @@ struct TagRepository: TagRepositoryProtocol {
                 }
             }
         } catch {
-            print(error.localizedDescription)
+            Logger.tagRepository.error("Failed to read the tag list: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -115,7 +116,7 @@ struct TagRepository: TagRepositoryProtocol {
             }
             return true
         } catch {
-            print(error.localizedDescription)
+            Logger.tagRepository.error("Failed to save the tag list: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -128,7 +129,7 @@ struct TagRepository: TagRepositoryProtocol {
         do {
             return try decoder.decode([TagEntity].self, from: content)
         } catch {
-            print("Data file format error: ", error.localizedDescription)
+            Logger.tagRepository.error("Tag list file format error: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -137,7 +138,9 @@ struct TagRepository: TagRepositoryProtocol {
         do {
             try fileManager.startDownloadingUbiquitousItem(at: url)
         } catch {
-            print(error.localizedDescription)
+            Logger.tagRepository.error(
+                "Failed to start downloading the tag list: \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 }

--- a/PiecesOfPaper/View/NoteList/NoteGridView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteGridView.swift
@@ -12,13 +12,14 @@ struct NoteGridView: View {
             Spacer(minLength: 30.0)
             LazyVGrid(columns: [gridItem]) {
                 ForEach(noteStore.displayEntries(for: directory)) { entry in
+                    let tags = tagStore.tags(ids: noteStore.tagIds(for: entry))
                     VStack {
-                        NoteThumbnailView(entry: entry)
+                        NoteThumbnailView(entry: entry, tags: tags)
                         .contextMenu {
                             contextMenu(entry: entry)
                         }
                         NoteListTagHStack(
-                            tags: tagStore.tags(ids: noteStore.tagIds(for: entry)),
+                            tags: tags,
                             action: {
                                 presentation.requestTag(entry, from: noteStore)
                             }

--- a/PiecesOfPaper/View/NoteList/NoteThumbnailView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteThumbnailView.swift
@@ -3,6 +3,7 @@ import PencilKit
 
 struct NoteThumbnailView: View {
     let entry: NoteIndexEntry
+    let tags: [TagEntity]
     @Environment(NoteStore.self) private var noteStore
     @Environment(NoteListPresentation.self) private var presentation
     @State private var thumbnail: UIImage?
@@ -28,7 +29,8 @@ struct NoteThumbnailView: View {
                 }
             }
         })
-        .accessibilityLabel("Note")
+        .accessibilityLabel(Self.accessibilityLabel(updatedDate: entry.updatedDate,
+                                                    tagNames: tags.map(\.name)))
         .task(id: entry.updatedDate) {
             let key = ThumbnailCache.key(for: entry)
             if let cached = ThumbnailCache.shared.cached(key: key),
@@ -43,6 +45,17 @@ struct NoteThumbnailView: View {
             guard !Task.isCancelled else { return }
             thumbnail = await ThumbnailCache.shared.thumbnail(for: note.entity.drawing, key: key)
         }
+    }
+
+    // Notes have no title, so the update date (and tag names, once the
+    // metadata cache knows them) is what distinguishes them under VoiceOver
+    static func accessibilityLabel(updatedDate: Date, tagNames: [String],
+                                   locale: Locale = .current) -> String {
+        let date = updatedDate.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened).locale(locale)
+        )
+        guard !tagNames.isEmpty else { return "Note, \(date)" }
+        return "Note, \(date), tags: \(tagNames.joined(separator: ", "))"
     }
 
     // Open-then-present: CanvasView reads the drawing synchronously in
@@ -65,7 +78,8 @@ struct NoteThumbnailView: View {
 #Preview {
     NoteThumbnailView(entry: NoteIndexEntry(fileURL: URL(fileURLWithPath: "/preview/2026-01-01-00-00-000000.pop"),
                                             creationDate: nil,
-                                            contentModificationDate: nil))
+                                            contentModificationDate: nil),
+                      tags: [])
         .environment(NoteStore())
         .environment(NoteListPresentation())
 }

--- a/PiecesOfPaperTests/NoteThumbnailViewTests.swift
+++ b/PiecesOfPaperTests/NoteThumbnailViewTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import Pieces_of_Paper
+
+struct NoteThumbnailViewTests {
+    private let locale = Locale(identifier: "en_US")
+
+    @Test func accessibilityLabelWithoutTagsContainsFormattedDate() {
+        let updatedDate = Date(timeIntervalSince1970: 1_000_000)
+        let label = NoteThumbnailView.accessibilityLabel(updatedDate: updatedDate, tagNames: [], locale: locale)
+
+        let expectedDate = updatedDate.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened).locale(locale)
+        )
+        #expect(label == "Note, \(expectedDate)")
+        #expect(!label.contains("tags:"))
+    }
+
+    @Test func accessibilityLabelWithTagsAppendsTagNames() {
+        let label = NoteThumbnailView.accessibilityLabel(updatedDate: Date(timeIntervalSince1970: 1_000_000),
+                                                         tagNames: ["idea", "memo"],
+                                                         locale: locale)
+        #expect(label.hasPrefix("Note, "))
+        #expect(label.hasSuffix(", tags: idea, memo"))
+    }
+
+    @Test func accessibilityLabelDistinguishesNotesByDate() {
+        let first = NoteThumbnailView.accessibilityLabel(updatedDate: Date(timeIntervalSince1970: 1_000_000),
+                                                         tagNames: [],
+                                                         locale: locale)
+        let second = NoteThumbnailView.accessibilityLabel(updatedDate: Date(timeIntervalSince1970: 2_000_000),
+                                                          tagNames: [],
+                                                          locale: locale)
+        #expect(first != second)
+    }
+}

--- a/docs/progress/2026-07-25-improve-a11y-and-logging.md
+++ b/docs/progress/2026-07-25-improve-a11y-and-logging.md
@@ -1,0 +1,4 @@
+- [x] Improve accessibility labels, error visibility, and logging (issue #222, PR #246)
+  - Note thumbnail VoiceOver label is now "Note, \<updated date\>[, tags: ...]" instead of a bare "Note"; tag names are passed in from NoteGridView, which already resolves them for NoteListTagHStack
+  - New Logger+App.swift: os.Logger with subsystem Individual.LikeAPaper and per-type categories; all 6 print() error logs replaced. Error descriptions logged with privacy: .public (file-operation errors only, never note content)
+  - FilePath.makeDirectoryIfNeeded logs creation failures instead of try?; signature stays non-throwing (sole caller is a didSet observer) and withIntermediateDirectories stays false so a missing parent surfaces in the log


### PR DESCRIPTION
Closes #222

## Summary

Three self-contained improvements from the issue:

1. **Distinguishable VoiceOver labels for note thumbnails** — the note list previously announced every thumbnail as "Note". The label now includes the note's update date and, when known, its tag names: `Note, <date>` or `Note, <date>, tags: a, b`. The label is built by a pure static helper on `NoteThumbnailView` (unit-tested); tag names are passed in from `NoteGridView`, which already resolves them for `NoteListTagHStack`, so no extra tag lookups happen. Tags come from the metadata cache, so a note that has never been opened degrades gracefully to the date-only label.
2. **`os.Logger` instead of `print()`** — new `Logger+App.swift` defines per-type loggers (subsystem `Individual.LikeAPaper`, categories `TagRepository` / `NoteMetadataCache` / `NoteDocument` / `FilePath`). All 6 `print()` error logs in `TagRepository`, `NoteMetadataCacheRepository`, and `NoteDocument` are now `Logger.error(...)`. Error descriptions use `privacy: .public` so release-build logs stay readable in Console; they contain file-operation errors only, never note content.
3. **`FilePath.makeDirectoryIfNeeded` no longer swallows errors** — `try?` is replaced with do/catch + `Logger.filePath.error`. The signature stays non-throwing because the only caller is a `didSet` observer (`PreferenceStore.enablediCloud`), which cannot propagate. `withIntermediateDirectories` stays `false`: the parent is the system-provided Documents directory, so a missing parent now surfaces in the log instead of being silently created or silently failing.

No behavior change outside the accessibility label and logging output.

## Verification

- Full unit-test suite passes on the iOS Simulator, including the 3 new `NoteThumbnailViewTests` cases (confirmed present in the run output, not just overall green).
- SwiftLint: no new warnings on changed files.
- PencilKit rendering is untouched, so no physical-device verification is required per CLAUDE.md.
