### PR TITLE
Improve readability of the Quick Tutorial page

### DIFF
--- a/PiecesOfPaper/View/Tutorial/TutorialView.swift
+++ b/PiecesOfPaper/View/Tutorial/TutorialView.swift
@@ -3,62 +3,197 @@ import SwiftUI
 struct TutorialView: View {
     var body: some View {
         ScrollView {
-            Text("""
-            **Basis**
-
-            - Pieces of Paper is designed specifically for iPad and Apple Pencil
-            - The iOS app exists but offers limited practical value
-            - When you launch the app, it displays a blank white canvas across the entire screen. You can immediately start writing with your Apple Pencil. Double-tapping the Apple Pencil switches to eraser mode
-            - Tapping the screen with your finger reveals additional tools, and pressing the Done button in the top right closes the window
-            - The app features auto-save functionality, which can be disabled in settings
-
-            **Data Management**
-
-            - By default, this app uses your iCloud storage. This enables data synchronization across devices
-            - You can also use local storage without iCloud. Turn it off in Setting > Enable iCloud.
-            - There is one major issue with iCloud integration. You cannot download files created on other devices directly from Pieces of Paper. Please note that you need to open the Files app to sync them
-
-            **Archive**
-
-            - The app includes an archive feature
-            - It's designed to work like Gmail's archive system
-              - Maybe you don't use or dislike
-            - Archiving an item doesn't delete the actual file - additional steps are required for permanent deletion
-
-            **Tag**
-
-            - The app includes a tag feature
-            - You can add/remove tags via Tag List
-            - Tag list files are stored in iCloud or local storage
-            - The path is Library/taglist.json
-            - If synchronization issues occur during device migration or iCloud setting changes, manually manage storage and select the appropriate file
-
-            **Infinite Canvas**
-
-            - You can use infinite canvas by default
-            - Write something on the bottom-right corner of your note to expand the canvas
-            - Toggle this feature on/off in settings
-
-            **Important Notes**
-
-            - I have identified an issue where files created on iCloud may become inaccessible. While the exact conditions are unknown, this can potentially cause the entire app to hang.
-            - In the developer's environment, this occurred after creating more than 500 files. However, I've confirmed that other files remain usable once the problematic files are removed.
-            - If you encounter this issue, you can recover by creating a backup folder in your iCloud storage, backing up all files from Pieces of Paper's Inbox, and then attempting to delete everything in Inbox
-
-            **FAQ**
-
-            Q: Is this app free?
-            A: Yes, it's **free**. In fact, all the source code is [publicly available](https://github.com/0si43/PiecesOfPaper).
-
-            Q: Where should I report bugs?
-            A: Please create an issue on [GitHub Repository](https://github.com/0si43/PiecesOfPaper). However, I cannot promise to fix every issue (as this is a free app!). If you're a developer, I'd be delighted to receive your pull requests!😁
-
-            Q: This app's bug ruined my notes! I worked hard on those notes and now they're gone! This is terrible!
-            A: Sorry for your inconvenience. Please note that Pieces of Paper is developed by an individual developer and offered as a free app.
-
-            While I'm confident in the app's usability, I cannot guarantee 100% stability. For important documents, I cannot take responsibility for any data loss. I recommend regularly exporting your work as image files or using a more reliable app for critical documents.
-            """)
+            VStack(alignment: .leading, spacing: 32) {
+                basics
+                Divider()
+                dataManagement
+                Divider()
+                archive
+                Divider()
+                tag
+                Divider()
+                infiniteCanvas
+                Divider()
+                importantNotes
+                Divider()
+                faq
+            }
+            .frame(maxWidth: 720, alignment: .leading)
+            .frame(maxWidth: .infinity)
             .padding()
+        }
+    }
+
+    private var basics: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Basics", systemImage: "pencil.tip.crop.circle")
+            Bullet("Pieces of Paper is designed specifically for iPad and Apple Pencil")
+            Bullet("The iOS app exists but offers limited practical value")
+            Bullet("""
+            When you launch the app, it displays a blank white canvas across the entire screen, \
+            and you can immediately start writing with your Apple Pencil
+            """)
+            Bullet("Double-tapping the Apple Pencil switches to eraser mode")
+            Bullet("""
+            Tapping the screen with your finger reveals additional tools, \
+            and pressing the Done button in the top right closes the window
+            """)
+            Bullet("The app features auto-save, which can be turned off in Setting > Auto Save")
+        }
+    }
+
+    private var dataManagement: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Data Management", systemImage: "icloud")
+            Bullet("""
+            By default, this app uses your iCloud storage. \
+            This enables data synchronization across devices
+            """)
+            Bullet("""
+            You can also use local storage without iCloud. \
+            Turn it off in Setting > Enable iCloud
+            """)
+            Bullet("""
+            There is one major issue with iCloud integration. \
+            You cannot download files created on other devices directly from Pieces of Paper. \
+            Please note that you need to open the Files app to sync them
+            """)
+        }
+    }
+
+    private var archive: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Archive", systemImage: "archivebox")
+            Bullet("The app includes an archive feature")
+            Bullet("It's designed to work like Gmail's archive system (which you may not use, or may even dislike)")
+            Bullet("""
+            Archiving an item doesn't delete the actual file - \
+            additional steps are required for permanent deletion
+            """)
+        }
+    }
+
+    private var tag: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Tag", systemImage: "tag")
+            Bullet("The app includes a tag feature")
+            Bullet("You can add/remove tags via Tag List")
+            Bullet("Tag list files are stored in iCloud or local storage")
+            Bullet("The path is Library/taglist.json")
+            Bullet("""
+            If synchronization issues occur during device migration or iCloud setting changes, \
+            manually manage storage and select the appropriate file
+            """)
+        }
+    }
+
+    private var infiniteCanvas: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Infinite Canvas", systemImage: "scroll")
+            Bullet("You can use infinite canvas by default")
+            Bullet("Write something on the bottom-right corner of your note to expand the canvas")
+            Bullet("Toggle this feature on/off in Setting > Infinite Scroll")
+        }
+    }
+
+    private var importantNotes: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Important Notes", systemImage: "exclamationmark.triangle")
+            Bullet("""
+            I have identified an issue where files created on iCloud may become inaccessible. \
+            While the exact conditions are unknown, this can potentially cause the entire app to hang
+            """)
+            Bullet("""
+            In the developer's environment, this occurred after creating more than 500 files. \
+            However, I've confirmed that other files remain usable once the problematic files are removed
+            """)
+            Bullet("""
+            If you encounter this issue, you can recover by creating a backup folder in your iCloud storage, \
+            backing up all files from Pieces of Paper's Inbox, \
+            and then attempting to delete everything in Inbox
+            """)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.yellow.opacity(0.15), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var faq: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            SectionHeader(title: "FAQ", systemImage: "questionmark.circle")
+            FAQItem(
+                question: "Is this app free?",
+                answer: """
+                Yes, it's **free**. In fact, all the source code is \
+                [publicly available](https://github.com/0si43/PiecesOfPaper).
+                """
+            )
+            FAQItem(
+                question: "Where should I report bugs?",
+                answer: """
+                Please create an issue on [GitHub Repository](https://github.com/0si43/PiecesOfPaper). \
+                However, I cannot promise to fix every issue (as this is a free app!). \
+                If you're a developer, I'd be delighted to receive your pull requests!😁
+                """
+            )
+            FAQItem(
+                question: """
+                This app's bug ruined my notes! I worked hard on those notes and now they're gone! \
+                This is terrible!
+                """,
+                answer: """
+                Sorry for your inconvenience. Please note that Pieces of Paper is developed by \
+                an individual developer and offered as a free app.
+
+                While I'm confident in the app's usability, I cannot guarantee 100% stability. \
+                For important documents, I cannot take responsibility for any data loss. \
+                I recommend regularly exporting your work as image files or using a more reliable app \
+                for critical documents.
+                """
+            )
+        }
+    }
+}
+
+private struct SectionHeader: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.title2.bold())
+    }
+}
+
+private struct Bullet: View {
+    private let text: LocalizedStringKey
+
+    init(_ text: LocalizedStringKey) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("•")
+                .foregroundStyle(.secondary)
+            Text(text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct FAQItem: View {
+    let question: LocalizedStringKey
+    let answer: LocalizedStringKey
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(question)
+                .font(.headline)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(answer)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/docs/progress/2026-07-25-improve-tutorial-readability.md
+++ b/docs/progress/2026-07-25-improve-tutorial-readability.md
@@ -1,0 +1,5 @@
+- [x] Improve readability of the Quick Tutorial page (issue #243, PR #247)
+  - Rebuilt `TutorialView` from one multi-line `Text` literal into section headers (`Label` + SF Symbol), real bullet rows, and FAQ question/answer pairs, all as private views in the same file
+  - Column capped at 720pt and centered in the split-view detail pane; "Important Notes" styled as a tinted callout
+  - Copy cleanup only: `Basis` → `Basics`, actual Setting toggle names spelled out, overloaded bullets split, dangling nested Archive item folded into its parent
+  - The issue's proposed `Bullet` `level` parameter was dropped as dead code — no nested bullets remain after the copy cleanup


### PR DESCRIPTION
Closes #243

## Summary

Rebuilds the Quick Tutorial page from a single multi-line `Text` literal into a typographic hierarchy, entirely within `TutorialView.swift`.

- `ScrollView` > `VStack(alignment: .leading, spacing: 32)` with a `Divider()` between sections; the column is capped at `maxWidth: 720` and centered in the wide `NavigationSplitView` detail pane.
- New private views in the same file:
  - `SectionHeader` — `Label` with an SF Symbol per section at `.font(.title2.bold())`.
  - `Bullet` — `•` marker in `.secondary` aligned at the first text baseline; body typed `LocalizedStringKey` with `.fixedSize(horizontal: false, vertical: true)`.
  - `FAQItem` — question at `.headline`, answer in `.secondary`; markdown links and `**free**` keep rendering.
- "Important Notes" gets a callout treatment: yellow-tinted rounded background around the whole section.
- Copy cleanup only, no information added or removed: `Basis` → `Basics`, actual toggle names spelled out (`Setting > Auto Save` / `Enable iCloud` / `Infinite Scroll`), the launch-canvas bullet split from the double-tap-eraser bullet, and the dangling nested Archive item folded into its parent sentence.

### Deviation from the issue

The proposed `Bullet` `level` parameter is omitted: after folding the only nested item into its parent, no nested bullets remain, so the parameter would be dead code.

## Verification

- Built and ran on an iPad Pro 13-inch simulator (temporary `TEMP-VERIFY` change to land on the tutorial page, reverted before commit; final build + full test run repeated on the clean tree — 133 tests in 20 suites passed).
- Screenshots checked (light, dark, largest accessibility Dynamic Type):
  - headings visibly larger than body, dividers between sections, bullets render as `•`;
  - column centered with margins on the 1032pt-wide detail pane;
  - "Important Notes" reads as a tinted callout with good contrast in dark mode;
  - GitHub links render as links, `**free**` renders bold, FAQ answer keeps its two paragraphs;
  - largest accessibility type wraps without truncation.
- Also checked on iPhone SE (iOS 18.3.1) for compact width. Note: the 😁 emoji renders as tofu on the iOS 26.5 simulator runtime but correctly on iOS 18.3.1; the source bytes are valid UTF-8 and unchanged from the previous copy, so this is a runtime rendering quirk, not a regression.
- No physical-device check needed: no PencilKit or canvas code touched.
