### PR TITLE
Limit blank-note auto-open to cold launch and long background resume

### DIFF
--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -33,6 +33,8 @@ final class NoteStore {
     /// External opens can fail while no note list is mounted, so this one is
     /// presented by RootSplitView rather than by a list screen
     var showExternalOpenAlert = false
+    @ObservationIgnored private var hasBecomeActive = false
+    @ObservationIgnored private var lastEnteredBackground: Date?
 
     // MARK: - Dependencies
     private let noteRepository: NoteRepositoryProtocol
@@ -284,6 +286,29 @@ extension NoteStore {
     func openBlankNoteIfIdle() {
         guard openedNote == nil, !isHandlingExternalOpen else { return }
         openNewNote()
+    }
+
+    /// Not cold-launch-only: iOS keeps the process alive for days, so "open the
+    /// app next morning" is usually a foreground resume. The threshold keeps
+    /// the open-and-write experience for those while short app switches resume
+    /// quietly.
+    static let autoOpenBackgroundThreshold: TimeInterval = 30 * 60
+
+    func sceneDidEnterBackground(now: Date = .now) {
+        lastEnteredBackground = now
+    }
+
+    /// Auto-opens a blank note on cold launch or after a long background stay.
+    /// Brief interruptions (.inactive bounces, short app switches) never
+    /// re-trigger it
+    func sceneDidBecomeActive(now: Date = .now) {
+        let isColdLaunch = !hasBecomeActive
+        hasBecomeActive = true
+        let resumedAfterLongBackground = lastEnteredBackground
+            .map { now.timeIntervalSince($0) >= Self.autoOpenBackgroundThreshold } ?? false
+        lastEnteredBackground = nil
+        guard isColdLaunch || resumedAfterLongBackground else { return }
+        openBlankNoteIfIdle()
     }
 
     /// Synchronous onOpenURL entry point. Sets the suppression flag before any

--- a/PiecesOfPaper/View/NoteList/NoteListScreen.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListScreen.swift
@@ -5,7 +5,6 @@ struct NoteListScreen: View {
     let directory: NoteDirectory
     @Environment(NoteStore.self) private var noteStore
     @Environment(PreferenceStore.self) private var preferenceStore
-    @Environment(\.scenePhase) private var scenePhase
     @Environment(\.displayScale) private var displayScale
     @State private var showListOrderSettingView = false
     @State private var presentation = NoteListPresentation()
@@ -90,15 +89,6 @@ struct NoteListScreen: View {
                 case let .error(error):
                     return Text(error.localizedDescription)
                 }
-        }
-        .onChange(of: scenePhase) { _, phase in
-            switch phase {
-            case .active:
-                guard !preferenceStore.shouldGrantiCloud else { return }
-                noteStore.openBlankNoteIfIdle()
-            default:
-                break
-            }
         }
         // Outermost so the grid, its cells, and the sheets above all see it
         .environment(presentation)

--- a/PiecesOfPaper/View/Root/RootSplitView.swift
+++ b/PiecesOfPaper/View/Root/RootSplitView.swift
@@ -65,11 +65,18 @@ struct RootSplitView: View {
         } message: {
             Text(NoteStoreError.openFailed(count: 1).localizedDescription)
         }
-        // The store owner, so the flush happens once per app, not once per
-        // NoteListParentView
+        // The store owner, so each transition is handled once per app, not
+        // once per NoteListScreen instance
         .onChange(of: scenePhase) { _, phase in
-            if phase == .background {
+            switch phase {
+            case .active:
+                guard !preferenceStore.shouldGrantiCloud else { return }
+                noteStore.sceneDidBecomeActive()
+            case .background:
+                noteStore.sceneDidEnterBackground()
                 noteStore.flushMetadataCache()
+            default:
+                break
             }
         }
         .environment(noteStore)

--- a/PiecesOfPaperTests/NoteStoreCanvasPresentationTests.swift
+++ b/PiecesOfPaperTests/NoteStoreCanvasPresentationTests.swift
@@ -96,4 +96,51 @@ struct NoteStoreCanvasPresentationTests {
         await noteStore.externalOpenTask?.value
         #expect(noteStore.openedNote == notes[0])
     }
+
+    @Test func test_sceneDidBecomeActive_opensBlankNoteOnColdLaunch() {
+        noteStore.sceneDidBecomeActive(now: .now)
+        #expect(noteStore.openedNote != nil)
+    }
+
+    @Test func test_sceneDidBecomeActive_skipsResumeAfterShortBackground() {
+        let launch = Date(timeIntervalSinceReferenceDate: 0)
+        noteStore.sceneDidBecomeActive(now: launch)
+        noteStore.openedNote = nil
+        noteStore.sceneDidEnterBackground(now: launch.addingTimeInterval(60))
+        noteStore.sceneDidBecomeActive(now: launch.addingTimeInterval(120))
+        #expect(noteStore.openedNote == nil)
+    }
+
+    @Test func test_sceneDidBecomeActive_opensAfterLongBackground() {
+        let launch = Date(timeIntervalSinceReferenceDate: 0)
+        noteStore.sceneDidBecomeActive(now: launch)
+        noteStore.openedNote = nil
+        noteStore.sceneDidEnterBackground(now: launch.addingTimeInterval(60))
+        noteStore.sceneDidBecomeActive(
+            now: launch.addingTimeInterval(60 + NoteStore.autoOpenBackgroundThreshold)
+        )
+        #expect(noteStore.openedNote != nil)
+    }
+
+    @Test func test_sceneDidBecomeActive_skipsActiveBounceWithoutBackground() {
+        let launch = Date(timeIntervalSinceReferenceDate: 0)
+        noteStore.sceneDidBecomeActive(now: launch)
+        noteStore.openedNote = nil
+        noteStore.sceneDidBecomeActive(
+            now: launch.addingTimeInterval(NoteStore.autoOpenBackgroundThreshold * 2)
+        )
+        #expect(noteStore.openedNote == nil)
+    }
+
+    @Test func test_sceneDidBecomeActive_keepsOpenNoteAfterLongBackground() {
+        let launch = Date(timeIntervalSinceReferenceDate: 0)
+        noteStore.sceneDidBecomeActive(now: launch)
+        let note = NoteData.createTestData()
+        noteStore.openedNote = note
+        noteStore.sceneDidEnterBackground(now: launch.addingTimeInterval(60))
+        noteStore.sceneDidBecomeActive(
+            now: launch.addingTimeInterval(60 + NoteStore.autoOpenBackgroundThreshold)
+        )
+        #expect(noteStore.openedNote == note)
+    }
 }

--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -87,7 +87,7 @@ device and the real Files app. Background: PR #208.
   the note list, and settings are currently unreachable from idb. Planned complement: a
   Simulator-only keyboard shortcut driven by `idb ui key` (issue #196 follow-up).
   Workaround until then: to exercise the note list, build a throwaway build with the
-  `noteStore.openBlankNoteIfIdle()` call in `NoteListParentView` stubbed out — the app then
+  `noteStore.sceneDidBecomeActive()` call in `RootSplitView` stubbed out — the app then
   launches into the list instead of a blank canvas. Revert the stub and rebuild before
   running the verification that goes into the PR.
 - **Companion version**: the brew bottle is idb-companion 1.1.8 (built 2022). `ui swipe`

--- a/docs/progress/2026-07-25-auto-open-on-foreground-resume.md
+++ b/docs/progress/2026-07-25-auto-open-on-foreground-resume.md
@@ -1,0 +1,2 @@
+- [x] Limit blank-note auto-open to cold launch and long background resume (issue #252, PR #253)
+  - scenePhase handling consolidated into RootSplitView; NoteStore gates openBlankNoteIfIdle with a 30-minute background threshold (injectable clock, unit-tested)


### PR DESCRIPTION
Closes #252

## Summary

Opening the app auto-presents a blank note — intentional. But the trigger reacted to every scenePhase `.active` transition, so the blank canvas also stacked on every background → foreground resume once the user had closed a note. This PR limits the auto-open to:

1. **cold launch**, and
2. **foreground resume after ≥ 30 minutes in the background**.

Short app switches and transient interruptions (Control Center, App Switcher peek) now resume quietly. A cold-launch-only rule was rejected because iOS keeps the process alive for days — resuming next morning should still land on a blank note.

## Changes

- `NoteStore`: new `sceneDidBecomeActive(now:)` / `sceneDidEnterBackground(now:)` track the scene lifecycle (`hasBecomeActive`, `lastEnteredBackground`) and gate the existing `openBlankNoteIfIdle()`. `now` is injectable for tests. `.inactive` bounces never re-trigger because they don't pass through `.background`.
- `RootSplitView`: the scenePhase observation is consolidated here (it already watched `.background` for the metadata-cache flush). The `shouldGrantiCloud` guard moves along with it.
- `NoteListScreen`: its per-instance scenePhase observer is removed. **Behavior change (intentional):** the auto-open now also fires when resuming on the Tag/Tutorial/Setting pages, instead of only while a note list was mounted, and no longer fires twice (Inbox + Trash instances).
- `docs/SIMULATOR_E2E.md`: the throwaway-stub workaround now points at the new trigger call site.

## Testing

- 5 new unit tests in `NoteStoreCanvasPresentationTests` (cold launch opens; short resume skips; long resume opens; `.inactive` bounce skips; open note is never stomped). Full suite: 138 tests / 20 suites passed, new test names confirmed present in the run log.
- Simulator (dedicated device, threshold temporarily lowered to 10 s with a TEMP-VERIFY build, since reverted): verified all three behaviors live via lifecycle logs and screenshots — cold launch opens the canvas, a 9.6 s resume stays on the note list, a 20 s resume re-opens a blank canvas.
- Note: mid-verification, a concurrent session's `xcodebuild test` on the shared Simulator kept replacing the installed build with an old-behavior binary, which initially looked like the fix not working. Re-verified on a dedicated Simulator device.
- No canvas/PencilKit rendering paths are touched, so physical-iPad verification per CLAUDE.md is not required.
