### PR TITLE
Document initial-selection workaround for sidebar pages in Simulator E2E

### DIFF
--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -90,6 +90,11 @@ device and the real Files app. Background: PR #208.
   `noteStore.openBlankNoteIfIdle()` call in `NoteListParentView` stubbed out — the app then
   launches into the list instead of a blank canvas. Revert the stub and rebuild before
   running the verification that goes into the PR.
+  To land directly on a sidebar page instead (Quick Tutorial, Setting, Tag List), change
+  the initial `selection` in `RootSplitView` to that page (e.g. `.tutorial`) in the
+  throwaway build — the detail pane shows the page at launch, no blank note opens, and
+  idb swipes scroll it directly (used for the PR #247 screenshots). Same rule: revert and
+  rebuild before the verification that goes into the PR.
 - **Companion version**: the brew bottle is idb-companion 1.1.8 (built 2022). `ui swipe`
   verified against the iOS 18.3.1 and iOS 26.3 simulator runtimes.
 - idb cannot inject touches into physical devices (iOS restriction); this workflow is

--- a/docs/progress/2026-07-25-simulator-e2e-sidebar-pages.md
+++ b/docs/progress/2026-07-25-simulator-e2e-sidebar-pages.md
@@ -1,0 +1,2 @@
+- [x] Document the initial-selection workaround for reaching sidebar pages in Simulator E2E (issue #255, PR #256)
+  - `docs/SIMULATOR_E2E.md` Limitations: a throwaway build with `RootSplitView`'s initial `selection` set to the target page reaches Quick Tutorial / Setting / Tag List directly, lighter than stubbing `openBlankNoteIfIdle()`


### PR DESCRIPTION
Closes #255

## Summary

Adds the lighter workaround used for the PR #247 screenshots to the Limitations section of `docs/SIMULATOR_E2E.md`: to reach a sidebar page (Quick Tutorial, Setting, Tag List) from an automated Simulator session, change the initial `selection` in `RootSplitView` to that page in a throwaway build — the detail pane shows the page at launch, no blank note opens, and idb swipes scroll it directly. Includes the same revert-and-rebuild reminder as the existing stub workaround.

Docs only, no code changes.
