### PR TITLE
Surface bulk move failures and coalesce overlapping note fetches

### DIFF
--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -46,6 +46,10 @@ final class NoteStore {
     // at once; one UIDocument open serves all of them.
     private var inFlightLoads: [URL: Task<NoteData?, Never>] = [:]
 
+    // Pull-to-refresh, the Reload button, and cloud updates can request the
+    // same directory at once; one enumeration serves all of them.
+    private var inFlightFetches: [NoteDirectory: Task<Void, Never>] = [:]
+
     // Coordinated deletes and moves take an unbounded amount of time, so the
     // index is updated optimistically. The pending set hides files whose
     // operation has not landed yet from enumeration results, preventing a
@@ -96,6 +100,17 @@ final class NoteStore {
     func fetch(directory: NoteDirectory, background: Bool = false) async {
         defer { if !background { isLoading = false } }
         if !background { isLoading = true }
+        if let inFlight = inFlightFetches[directory] {
+            await inFlight.value
+            return
+        }
+        let fetchTask = Task { await performFetch(directory: directory) }
+        inFlightFetches[directory] = fetchTask
+        await fetchTask.value
+        inFlightFetches[directory] = nil
+    }
+
+    private func performFetch(directory: NoteDirectory) async {
         let entries = await noteRepository.getFileAttributes(directory: directory)
             .filter { !pendingFileOperationUrls.contains($0.fileURL) }
             .map {
@@ -103,9 +118,8 @@ final class NoteStore {
                                creationDate: $0.creationDate,
                                contentModificationDate: $0.contentModificationDate)
             }
-        // Wholesale assignment keeps overlapping fetches last-writer-wins; the
-        // equality guard avoids re-rendering (and re-running cell load tasks)
-        // when nothing changed.
+        // The equality guard avoids re-rendering (and re-running cell load
+        // tasks) when nothing changed.
         switch directory {
         case .inbox:
             if entries != inboxIndex { inboxIndex = entries }

--- a/PiecesOfPaper/Store/NoteStore.swift
+++ b/PiecesOfPaper/Store/NoteStore.swift
@@ -200,13 +200,28 @@ extension NoteStore {
         try await move(entry, to: .inbox)
     }
 
-    /// Best effort: a note whose move fails stays in place, and the rest still move.
-    func allArchive() async {
-        for entry in inboxIndex { try? await archive(entry) }
+    /// Continues past individual failures — a note whose move fails stays in
+    /// place (each move rolls itself back), and the total is reported at the end.
+    func allArchive() async throws {
+        try await moveAll(inboxIndex, to: .archived)
     }
 
-    func allUnarchive() async {
-        for entry in archivedIndex { try? await unarchive(entry) }
+    func allUnarchive() async throws {
+        try await moveAll(archivedIndex, to: .inbox)
+    }
+
+    private func moveAll(_ entries: [NoteIndexEntry], to directory: NoteDirectory) async throws {
+        var failedCount = 0
+        for entry in entries {
+            do {
+                try await move(entry, to: directory)
+            } catch {
+                failedCount += 1
+            }
+        }
+        if failedCount > 0 {
+            throw NoteStoreError.bulkMoveFailed(count: failedCount)
+        }
     }
 
     private func move(_ entry: NoteIndexEntry, to directory: NoteDirectory) async throws {

--- a/PiecesOfPaper/Store/NoteStoreError.swift
+++ b/PiecesOfPaper/Store/NoteStoreError.swift
@@ -5,6 +5,7 @@ enum NoteStoreError: LocalizedError, Equatable {
     case saveFailed
     case deleteFailed
     case moveFailed
+    case bulkMoveFailed(count: Int)
 
     var errorDescription: String? {
         switch self {
@@ -16,6 +17,8 @@ enum NoteStoreError: LocalizedError, Equatable {
             "Failed to delete the note."
         case .moveFailed:
             "Failed to move the note."
+        case .bulkMoveFailed(let count):
+            "Failed to move \(count) note(s). They remain in place."
         }
     }
 }

--- a/PiecesOfPaper/View/NoteList/NoteListScreen.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListScreen.swift
@@ -193,10 +193,14 @@ struct NoteListScreen: View {
     private var archiveActionButton: some View {
         Button(role: .destructive) {
             Task {
-                if isTargetDirectoryArchived {
-                    await noteStore.allUnarchive()
-                } else {
-                    await noteStore.allArchive()
+                do {
+                    if isTargetDirectoryArchived {
+                        try await noteStore.allUnarchive()
+                    } else {
+                        try await noteStore.allArchive()
+                    }
+                } catch {
+                    presentation.alert = .error(error)
                 }
             }
         } label: {

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -202,15 +202,54 @@ struct NoteStoreTests {
         #expect(noteStore.displayArchivedEntries.isEmpty)
     }
 
-    @Test func test_allArchive_movesEveryEntryInOrder() async {
+    @Test func test_allArchive_movesEveryEntryInOrder() async throws {
         await noteStore.fetch(directory: .inbox)
         let urls = noteStore.inboxIndex.map(\.fileURL)
 
-        await noteStore.allArchive()
+        try await noteStore.allArchive()
 
         #expect(repositoryMock.movedUrls == urls)
         #expect(noteStore.inboxIndex.isEmpty)
         #expect(noteStore.archivedIndex.count == urls.count)
+    }
+
+    @Test func test_allArchive_movesRemainingNotesAndThrowsAggregateErrorWhenOneMoveFails() async {
+        await noteStore.fetch(directory: .inbox)
+        let failingUrl = NoteRepositoryMock.TestFile.file2.url
+        repositoryMock.moveFailingUrls = [failingUrl]
+
+        await #expect(throws: NoteStoreError.bulkMoveFailed(count: 1)) {
+            try await noteStore.allArchive()
+        }
+
+        #expect(noteStore.inboxIndex.map(\.fileURL) == [failingUrl])
+        #expect(noteStore.archivedIndex.count == 2)
+    }
+
+    @Test func test_allArchive_reportsTotalCountWhenEveryMoveFails() async {
+        await noteStore.fetch(directory: .inbox)
+        repositoryMock.moveShouldThrow = true
+
+        await #expect(throws: NoteStoreError.bulkMoveFailed(count: 3)) {
+            try await noteStore.allArchive()
+        }
+
+        #expect(noteStore.inboxIndex.count == 3)
+        #expect(noteStore.archivedIndex.isEmpty)
+    }
+
+    @Test func test_allUnarchive_throwsAggregateErrorWhenAMoveFails() async throws {
+        await noteStore.fetch(directory: .inbox)
+        try await noteStore.allArchive()
+        let archivedUrl = try #require(noteStore.archivedIndex.first?.fileURL)
+        repositoryMock.moveFailingUrls = [archivedUrl]
+
+        await #expect(throws: NoteStoreError.bulkMoveFailed(count: 1)) {
+            try await noteStore.allUnarchive()
+        }
+
+        #expect(noteStore.archivedIndex.map(\.fileURL) == [archivedUrl])
+        #expect(noteStore.inboxIndex.count == 2)
     }
 
     // MARK: - Tag operations

--- a/PiecesOfPaperTests/NoteStoreTests.swift
+++ b/PiecesOfPaperTests/NoteStoreTests.swift
@@ -44,6 +44,47 @@ struct NoteStoreTests {
         #expect(noteStore.inboxIndex.map(\.fileURL) == [NoteRepositoryMock.TestFile.file1.url])
     }
 
+    @Test func test_fetch_coalescesOverlappingFetchesForTheSameDirectory() async {
+        repositoryMock.suspendGetFileAttributes = true
+
+        async let first: Void = noteStore.fetch(directory: .inbox)
+        async let second: Void = noteStore.fetch(directory: .inbox)
+        await waitUntil { repositoryMock.hasPendingGetFileAttributes }
+        repositoryMock.suspendGetFileAttributes = false
+        repositoryMock.resumePendingGetFileAttributes()
+        _ = await (first, second)
+
+        #expect(repositoryMock.getFileAttributesCallCount == 1)
+        #expect(noteStore.inboxIndex.count == 3)
+    }
+
+    @Test func test_fetch_runsAgainAfterThePreviousFetchCompletes() async {
+        await noteStore.fetch(directory: .inbox)
+        await noteStore.fetch(directory: .inbox)
+        #expect(repositoryMock.getFileAttributesCallCount == 2)
+    }
+
+    @Test func test_fetch_foregroundJoinerShowsSpinnerWhileJoinedBackgroundFetchRuns() async {
+        // isLoading starts true; the initial foreground fetch settles it to false
+        await noteStore.fetch(directory: .inbox)
+        repositoryMock.suspendGetFileAttributes = true
+
+        async let backgroundFetch: Void = noteStore.fetch(directory: .inbox, background: true)
+        await waitUntil { repositoryMock.hasPendingGetFileAttributes }
+        #expect(!noteStore.isLoading)
+
+        async let foregroundFetch: Void = noteStore.fetch(directory: .inbox)
+        await waitUntil { noteStore.isLoading }
+        #expect(noteStore.isLoading)
+
+        repositoryMock.suspendGetFileAttributes = false
+        repositoryMock.resumePendingGetFileAttributes()
+        _ = await (backgroundFetch, foregroundFetch)
+
+        #expect(!noteStore.isLoading)
+        #expect(repositoryMock.getFileAttributesCallCount == 2)
+    }
+
     // file1 has the oldest filename timestamp (created) but the newest
     // modification date (updated), so the two sort keys produce opposite orders
     @Test func test_displayEntries_sortsBothKeysAndOrdersOnIndexAlone() async {

--- a/PiecesOfPaperTests/RepositoryMocks.swift
+++ b/PiecesOfPaperTests/RepositoryMocks.swift
@@ -46,6 +46,7 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     var notes: [NoteData]
     var failingUrls: Set<URL> = []
     var moveShouldThrow = false
+    var moveFailingUrls: Set<URL> = []
     var deleteShouldThrow = false
     @MainActor private(set) var deletedUrls: [URL] = []
     @MainActor private(set) var movedUrls: [URL] = []
@@ -133,7 +134,7 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     @MainActor
     func move(fileUrl: URL, to directory: NoteDirectory) async throws -> URL {
         await suspendFileOperationIfNeeded()
-        if moveShouldThrow {
+        if moveShouldThrow || moveFailingUrls.contains(fileUrl) {
             throw NoteRepositoryError.directoryNotAvailable
         }
         movedUrls.append(fileUrl)

--- a/PiecesOfPaperTests/RepositoryMocks.swift
+++ b/PiecesOfPaperTests/RepositoryMocks.swift
@@ -60,6 +60,10 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
     @MainActor var suspendOpens = false
     @MainActor private var pendingOpens: [CheckedContinuation<Void, Never>] = []
     @MainActor var hasPendingOpen: Bool { !pendingOpens.isEmpty }
+    @MainActor private(set) var getFileAttributesCallCount = 0
+    @MainActor var suspendGetFileAttributes = false
+    @MainActor private var pendingGetFileAttributes: [CheckedContinuation<Void, Never>] = []
+    @MainActor var hasPendingGetFileAttributes: Bool { !pendingGetFileAttributes.isEmpty }
     private(set) var cloudUpdateHandler: (@MainActor () -> Void)?
 
     @MainActor
@@ -74,13 +78,25 @@ final class NoteRepositoryMock: NoteRepositoryProtocol {
         pendingFileOperations.removeAll()
     }
 
+    @MainActor
+    func resumePendingGetFileAttributes() {
+        pendingGetFileAttributes.forEach { $0.resume() }
+        pendingGetFileAttributes.removeAll()
+    }
+
     init(notes: [NoteData]) {
         self.notes = notes
     }
 
     @MainActor
     func getFileAttributes(directory: NoteDirectory) async -> [NoteFileAttributes] {
-        directory == .inbox ? enumeratedAttributes : []
+        getFileAttributesCallCount += 1
+        // Suspend once so overlapping fetches actually overlap on the main actor
+        await Task.yield()
+        if suspendGetFileAttributes {
+            await withCheckedContinuation { pendingGetFileAttributes.append($0) }
+        }
+        return directory == .inbox ? enumeratedAttributes : []
     }
 
     func fileAttributes(at fileUrl: URL) -> NoteFileAttributes? {

--- a/docs/progress/2026-07-25-issue-220-error-surfacing-fetch-guard.md
+++ b/docs/progress/2026-07-25-issue-220-error-surfacing-fetch-guard.md
@@ -1,0 +1,4 @@
+- [x] Surface bulk archive/unarchive failures and coalesce overlapping fetches (issue #220, PR #257)
+  - Bulk moves continue past per-note failures and throw an aggregate `bulkMoveFailed(count:)`, presented via the existing list alert
+  - `NoteStore.fetch` dedupes concurrent same-directory enumerations with an `inFlightFetches` task map (same pattern as `inFlightLoads`)
+  - Issue item on `refreshable { Task { ... } }` was already resolved by 6ac8cf4; no change needed


### PR DESCRIPTION
Closes #220

## Summary

Issue #220 lists three items; reconciled against current `main`, one was already fixed and two remained. This PR addresses the two remaining gaps.

### 1. Bulk archive/unarchive failures are now surfaced (issue item 1)

Single-note `delete`/`archive`/`unarchive` already throw and surface alerts via `NoteListPresentation`. The remaining silent path was the bulk operations: `allArchive()`/`allUnarchive()` swallowed per-note failures with `try? await`, and their call site ignored errors.

- `allArchive()`/`allUnarchive()` now continue past individual failures (each failed move already rolls its own note back) and throw an aggregate `NoteStoreError.bulkMoveFailed(count:)` at the end, mirroring the `.openFailed(count:)` precedent.
- The "Move all to Trash / Inbox" button in `NoteListScreen` catches the error and presents it through the existing alert, same as the single-note context-menu actions.

### 2. Overlapping fetches now coalesce per directory (issue item 3)

`fetch(directory:background:)` had no re-entry guard: `.task`, `.refreshable`, the Reload button, the local-storage toggle, and iCloud `applyCloudUpdate()` could all run concurrent enumerations of the same directory with last-writer-wins interleaving.

- Added `inFlightFetches: [NoteDirectory: Task<Void, Never>]` following the existing `inFlightLoads` dedupe pattern: the first caller runs the enumeration, later callers await the same task and return.
- Cancel-previous was rejected because awaiting callers (pull-to-refresh) must see the fetch complete; serialization was rejected because back-to-back enumerations of the same directory return the same listing.
- `isLoading` is toggled by each caller according to its own `background` flag around the shared await, so a foreground caller joining a background fetch still shows the spinner until the shared fetch lands. UX is unchanged.

### Issue item 2 (`refreshable { Task { ... } }`) — already resolved, no change

`NoteListScreen.refreshable` has directly awaited `noteStore.fetch(directory:background:true)` since 6ac8cf4, so the spinner already tracks completion. With the new coalescing guard, a pull-to-refresh that overlaps an in-flight fetch of the same directory now shares that fetch instead of racing it.

## Behavior changes

- Failing bulk archive/unarchive now shows an alert ("Failed to move N note(s). They remain in place.") instead of failing silently. Successful runs look identical.
- Overlapping refreshes of the same directory no longer re-enumerate; joiners reuse the in-flight result. No visible change expected.

## Tests

6 new tests (suite grew 136 → 142):

- `test_allArchive_movesRemainingNotesAndThrowsAggregateErrorWhenOneMoveFails`
- `test_allArchive_reportsTotalCountWhenEveryMoveFails`
- `test_allUnarchive_throwsAggregateErrorWhenAMoveFails`
- `test_fetch_coalescesOverlappingFetchesForTheSameDirectory`
- `test_fetch_runsAgainAfterThePreviousFetchCompletes`
- `test_fetch_foregroundJoinerShowsSpinnerWhileJoinedBackgroundFetchRuns`

Mock additions: per-URL move failure (`moveFailingUrls`), enumeration call counter and suspension (`suspendGetFileAttributes` trio, mirroring `suspendOpens`).

Verification:

- Full suite green on Simulator: 142 tests in 21 suites passed; the 6 new test names confirmed present in the run log.
- Negative probe: temporarily disabling the coalescing guard makes both coalescing tests fail (enumeration count 2 instead of 1), confirming the new tests actually detect guard removal. The probe change was reverted; the committed code is byte-identical to the green run.
- Existing concurrency test `test_fetch_doesNotResurrectAnEntryWhileItsDeleteIsInFlight` passes unchanged.
- No canvas/PencilKit surfaces touched, so no device verification is required.
