### PR TITLE
Update SIMULATOR_E2E docs: long-press, screenshot fallback, seeding, stale view name

### DIFF
--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -51,10 +51,11 @@ coordinate values).
 |-|-|
 | `idb ui swipe --udid $UDID x1 y1 x2 y2 --duration 0.5` | Draws one stroke on the canvas |
 | `idb ui tap --udid $UDID x y` | Single tap — starts a dot stroke under `.anyInput`, so not usable for the UI toggle |
+| `idb ui tap --udid $UDID x y --duration 1.2` | Long press — opens context menus. A same-point `ui swipe` does NOT register as a long press |
 | `idb ui key --udid $UDID <HID keycode>` (`--shift/--control/--option/--command`) | Hardware-keyboard event |
 | `idb ui text --udid $UDID "..."` | Types text |
 | `idb ui describe-all --udid $UDID` | Accessibility tree as JSON |
-| `idb screenshot --udid $UDID out.png` | Screenshot |
+| `xcrun simctl io $UDID screenshot out.png` | Screenshot (`idb screenshot` can fail with "No Image available to encode") |
 
 Assertions that need no screenshot diffing:
 
@@ -67,6 +68,23 @@ Assertions that need no screenshot diffing:
 Verified example: two swipes (`100 300 300 500`, `300 500 150 650`), then `describe-all`
 returned two "Pen, black" elements with matching frames and a new plist appeared in
 InboxFolder.
+
+## Seeding notes and tags without drawing
+
+List, tag, and share flows need existing notes; they can be seeded from macOS without
+drawing anything. A macOS `swift` script that mirrors the app's formats — `NoteEntity`
+encoded with `PropertyListEncoder` into `Documents/InboxFolder/<timestamp>.pop`, and a
+`[TagEntity]` JSON array into `Documents/Library/taglist.json` — written into the app
+container (`xcrun simctl get_app_container $UDID Individual.LikeAPaper data`) appears in
+the note list on the next launch, with tag strips rendered from the seeded `tagIds`.
+Keep the seeded drawing an empty `PKDrawing()` (see docs/GOTCHAS.md on PencilKit
+rendering off-device). Combined with the note-list stub below, this verified the tag
+sheet, filter chips, and share sheet for PR #248 entirely from the command line.
+
+Seed (and re-query the container path) only while no other session is using the
+simulator: parallel sessions install their own builds over each other and the data
+container can be replaced under you. Run verification on a dedicated simulator
+(`xcrun simctl create`, or any device no other session uses), not the shared default.
 
 ## Opening a note file via URL (onOpenURL path)
 
@@ -87,7 +105,7 @@ device and the real Files app. Background: PR #208.
   the note list, and settings are currently unreachable from idb. Planned complement: a
   Simulator-only keyboard shortcut driven by `idb ui key` (issue #196 follow-up).
   Workaround until then: to exercise the note list, build a throwaway build with the
-  `noteStore.openBlankNoteIfIdle()` call in `NoteListParentView` stubbed out — the app then
+  `noteStore.openBlankNoteIfIdle()` call in `NoteListScreen` stubbed out — the app then
   launches into the list instead of a blank canvas. Revert the stub and rebuild before
   running the verification that goes into the PR.
   To land directly on a sidebar page instead (Quick Tutorial, Setting, Tag List), change

--- a/docs/progress/2026-07-26-simulator-e2e-doc-update.md
+++ b/docs/progress/2026-07-26-simulator-e2e-doc-update.md
@@ -1,0 +1,3 @@
+- [x] Update SIMULATOR_E2E.md with PR #248 verification findings (issue #258, PR #259)
+  - Long press is `idb ui tap --duration` (same-point swipe does not fire); screenshots via `xcrun simctl io` (`idb screenshot` can fail); stale `NoteListParentView` reference corrected to `NoteListScreen`
+  - New section on seeding notes/tags into the app container from macOS, with the dedicated-simulator caveat for parallel sessions


### PR DESCRIPTION
## Summary

Docs-only update to `docs/SIMULATOR_E2E.md` with findings from the PR #248 verification session:

- **Long press**: added `idb ui tap x y --duration 1.2` to the command table (opens context menus). A same-point `ui swipe` does not register as a long press — that was the first attempt and it silently did nothing.
- **Screenshot**: replaced the `idb screenshot` row with `xcrun simctl io $UDID screenshot`; `idb screenshot` failed with "No Image available to encode" during the session.
- **Stale view name**: the note-list stub workaround referenced `NoteListParentView`, which no longer exists. This branch corrected it to `NoteListScreen`, then PR #253 moved the call itself to `noteStore.sceneDidBecomeActive()` in `RootSplitView` and updated the doc; the merge takes #253's version (verified against the current code).
- **New "Seeding notes and tags without drawing" section**: documents the macOS `swift` script approach (PropertyListEncoder `NoteEntity` → `.pop`, JSON `taglist.json`) that seeds the app container so list/tag/share flows can be exercised without drawing, plus the caveat that verification must run on a dedicated simulator because parallel sessions install their own builds over each other.

No code changes.

Closes #258
