### PR TITLE
Add an in-app appearance setting (System / Light / Dark)

### DIFF
--- a/PiecesOfPaper/Model/AppearanceMode.swift
+++ b/PiecesOfPaper/Model/AppearanceMode.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+enum AppearanceMode: String, CaseIterable, Identifiable {
+    // The case names are the persisted raw values, so the display text lives in
+    // `label` instead: renaming a case would reset every stored choice to .system
+    case system, light, dark
+
+    var id: String { self.rawValue }
+
+    var label: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}

--- a/PiecesOfPaper/PiecesOfPaperApp.swift
+++ b/PiecesOfPaper/PiecesOfPaperApp.swift
@@ -3,9 +3,15 @@ import PencilKit
 
 @main
 struct PiecesOfPaperApp: App {
+    // Owned here rather than by RootSplitView: UIApplicationSupportsMultipleScenes
+    // is on, and a per-scene @State would let two windows disagree about the
+    // preferences until relaunch
+    @State private var preferenceStore = PreferenceStore()
+
     var body: some Scene {
         WindowGroup {
             RootSplitView()
+                .environment(preferenceStore)
         }
     }
 }

--- a/PiecesOfPaper/Repository/PreferenceRepository.swift
+++ b/PiecesOfPaper/Repository/PreferenceRepository.swift
@@ -7,6 +7,8 @@ protocol PreferenceRepositoryProtocol {
     func setEnabledAutoSave(_ value: Bool)
     func getEnabledInfiniteScroll() -> Bool
     func setEnabledInfiniteScroll(_ value: Bool)
+    func getAppearanceMode() -> AppearanceMode
+    func setAppearanceMode(_ value: AppearanceMode)
     func getListOrder(directoryName: String) -> ListOrder
     func setListOrder(directoryName: String, listOrder: ListOrder)
 }
@@ -15,6 +17,7 @@ struct PreferenceRepository: PreferenceRepositoryProtocol {
     private let iCloudDisabledKey = "iCloud_disabled"
     private let autoSaveDisabledKey = "autosave_disabled"
     private let infiniteScrollKey = "infinite_scroll_disabled"
+    private let appearanceModeKey = "appearance_mode"
     private let listOrderKey = "com.pop.listOrder."
 
     func getEnablediCloud() -> Bool {
@@ -39,6 +42,18 @@ struct PreferenceRepository: PreferenceRepositoryProtocol {
 
     func setEnabledInfiniteScroll(_ value: Bool) {
         UserDefaults.standard.set(!value, forKey: infiniteScrollKey)
+    }
+
+    // Stored as its raw value, not through the Bool keys' "*_disabled" inversion
+    // (that trick only makes UserDefaults' false default mean "enabled") nor the
+    // JSONEncoder path ListOrder needs: an absent string already means .system
+    func getAppearanceMode() -> AppearanceMode {
+        guard let rawValue = UserDefaults.standard.string(forKey: appearanceModeKey) else { return .system }
+        return AppearanceMode(rawValue: rawValue) ?? .system
+    }
+
+    func setAppearanceMode(_ value: AppearanceMode) {
+        UserDefaults.standard.set(value.rawValue, forKey: appearanceModeKey)
     }
 
     func getListOrder(directoryName: String) -> ListOrder {

--- a/PiecesOfPaper/Store/PreferenceStore.swift
+++ b/PiecesOfPaper/Store/PreferenceStore.swift
@@ -26,6 +26,12 @@ final class PreferenceStore {
         }
     }
 
+    var appearanceMode: AppearanceMode {
+        didSet {
+            repository.setAppearanceMode(appearanceMode)
+        }
+    }
+
     // Stored, not computed: the system inputs (account, container URL) are not
     // observable, so views would never re-render on a computed property
     private(set) var cloudAvailability: CloudAvailability = .userDisabled
@@ -37,6 +43,7 @@ final class PreferenceStore {
         self.enablediCloud = repository.getEnablediCloud()
         self.enabledAutoSave = repository.getEnabledAutoSave()
         self.enabledInfiniteScroll = repository.getEnabledInfiniteScroll()
+        self.appearanceMode = repository.getAppearanceMode()
         refreshCloudAvailability()
     }
 

--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -180,7 +180,8 @@ struct CanvasView: View {
 
     private var activityViewController: UIActivityViewControllerWrapper {
         UIActivityViewControllerWrapper(
-            activityItems: [note.entity.drawing.lightModeImage(scale: displayScale)]
+            activityItems: [NoteShareItemSource(image: note.entity.drawing.lightModeImage(scale: displayScale),
+                                                updatedDate: note.entity.updatedDate)]
         )
     }
 

--- a/PiecesOfPaper/View/Canvas/NoteShareItemSource.swift
+++ b/PiecesOfPaper/View/Canvas/NoteShareItemSource.swift
@@ -1,0 +1,46 @@
+import UIKit
+import LinkPresentation
+
+/// Supplies the shared drawing together with a name for the share sheet header.
+/// A bare UIImage carries no metadata, so iOS falls back to naming the type and the
+/// header reads "PNG image" for every note (issue #270).
+final class NoteShareItemSource: NSObject, UIActivityItemSource {
+    private let image: UIImage
+    private let title: String
+
+    init(image: UIImage, updatedDate: Date, locale: Locale = .current) {
+        self.image = image
+        self.title = Self.title(updatedDate: updatedDate, locale: locale)
+        super.init()
+    }
+
+    // Notes have no title, so the update date is what distinguishes them — the same
+    // naming the grid uses under VoiceOver (NoteThumbnailView.accessibilityLabel)
+    static func title(updatedDate: Date, locale: Locale = .current) -> String {
+        let date = updatedDate.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened).locale(locale)
+        )
+        return "Note, \(date)"
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        image
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController,
+                                itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        image
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController,
+                                subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        title
+    }
+
+    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = title
+        metadata.imageProvider = NSItemProvider(object: image)
+        return metadata
+    }
+}

--- a/PiecesOfPaper/View/Canvas/NoteShareItemSource.swift
+++ b/PiecesOfPaper/View/Canvas/NoteShareItemSource.swift
@@ -40,7 +40,9 @@ final class NoteShareItemSource: NSObject, UIActivityItemSource {
     func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
         let metadata = LPLinkMetadata()
         metadata.title = title
-        metadata.imageProvider = NSItemProvider(object: image)
+        // iconProvider, not imageProvider: the latter is the large preview used for
+        // links and leaves the header without a thumbnail here
+        metadata.iconProvider = NSItemProvider(object: image)
         return metadata
     }
 }

--- a/PiecesOfPaper/View/Canvas/PKDrawingShareImage.swift
+++ b/PiecesOfPaper/View/Canvas/PKDrawingShareImage.swift
@@ -2,16 +2,26 @@ import PencilKit
 import UIKit
 
 extension PKDrawing {
-    /// Renders the drawing with light-mode colors for the share sheet.
+    /// Renders the drawing under an explicit interface style. PencilKit adapts
+    /// ink colors to the current trait, and outside a view update
+    /// UITraitCollection.current tracks neither the window nor its appearance
+    /// override, so callers state the style they want.
     /// @MainActor because off-main PKDrawing.image breaks stroke rendering
     /// process-wide on device (#187, docs/GOTCHAS.md)
     @MainActor
-    func lightModeImage(scale: CGFloat) -> UIImage {
+    func image(scale: CGFloat, style: UIUserInterfaceStyle) -> UIImage {
         var image = UIImage()
-        let trait = UITraitCollection(userInterfaceStyle: .light)
+        let trait = UITraitCollection(userInterfaceStyle: style)
         trait.performAsCurrent {
             image = self.image(from: bounds, scale: scale)
         }
         return image
+    }
+
+    /// Renders the drawing with light-mode colors for the share sheet, matching
+    /// what the QuickLook and Thumbnail extensions produce.
+    @MainActor
+    func lightModeImage(scale: CGFloat) -> UIImage {
+        image(scale: scale, style: .light)
     }
 }

--- a/PiecesOfPaper/View/Canvas/PKDrawingShareImage.swift
+++ b/PiecesOfPaper/View/Canvas/PKDrawingShareImage.swift
@@ -18,10 +18,23 @@ extension PKDrawing {
         return image
     }
 
-    /// Renders the drawing with light-mode colors for the share sheet, matching
-    /// what the QuickLook and Thumbnail extensions produce.
+    /// Renders the drawing with light-mode colors on an opaque white background for
+    /// the share sheet, matching what the QuickLook and Thumbnail extensions produce.
+    /// The fill is not decoration: PKDrawing.image leaves the background transparent,
+    /// and a viewer in dark mode composites that on black, hiding the dark ink the
+    /// light trait is there to preserve.
     @MainActor
     func lightModeImage(scale: CGFloat) -> UIImage {
-        image(scale: scale, style: .light)
+        let ink = image(scale: scale, style: .light)
+        guard ink.size.width > 0, ink.size.height > 0 else { return ink }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = scale
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: ink.size, format: format).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: ink.size))
+            ink.draw(at: .zero)
+        }
     }
 }

--- a/PiecesOfPaper/View/Canvas/UIActivityViewControllerWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/UIActivityViewControllerWrapper.swift
@@ -1,38 +1,14 @@
 import UIKit
 import SwiftUI
-import LinkPresentation
 
 struct UIActivityViewControllerWrapper: UIViewControllerRepresentable {
     var activityItems: [Any]
     var applicationActivities = [UIActivity]()
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        let items = activityItems + [context.coordinator]
-        let controller = UIActivityViewController(activityItems: items,
-                                                  applicationActivities: applicationActivities)
-        return controller
+        UIActivityViewController(activityItems: activityItems,
+                                 applicationActivities: applicationActivities)
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    class Coordinator: NSObject, UIActivityItemSource {
-        func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-            ""
-        }
-
-        func activityViewController(_ activityViewController: UIActivityViewController,
-                                    itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-            nil
-        }
-
-        func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
-            let metadata = LPLinkMetadata()
-            metadata.title = "Share your note"
-            return metadata
-        }
-    }
 }

--- a/PiecesOfPaper/View/Color+App.swift
+++ b/PiecesOfPaper/View/Color+App.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension Color {
+    /// Background for a highlighted callout block.
+    /// Defined in code rather than Assets.xcassets, which holds no color sets:
+    /// the same 15% yellow that reads as a highlight on white all but vanishes
+    /// on black, so Dark gets a stronger tint instead of the same value.
+    static let calloutBackground = Color(UIColor { traits in
+        let alpha: CGFloat = traits.userInterfaceStyle == .dark ? 0.28 : 0.15
+        return UIColor.systemYellow.resolvedColor(with: traits).withAlphaComponent(alpha)
+    })
+}

--- a/PiecesOfPaper/View/NoteList/NoteListScreen.swift
+++ b/PiecesOfPaper/View/NoteList/NoteListScreen.swift
@@ -191,7 +191,8 @@ struct NoteListScreen: View {
 
     private func activityViewController(note: NoteData) -> UIActivityViewControllerWrapper {
         UIActivityViewControllerWrapper(
-            activityItems: [note.entity.drawing.lightModeImage(scale: displayScale)]
+            activityItems: [NoteShareItemSource(image: note.entity.drawing.lightModeImage(scale: displayScale),
+                                                updatedDate: note.entity.updatedDate)]
         )
     }
 

--- a/PiecesOfPaper/View/NoteList/NoteThumbnailView.swift
+++ b/PiecesOfPaper/View/NoteList/NoteThumbnailView.swift
@@ -6,8 +6,19 @@ struct NoteThumbnailView: View {
     let tags: [TagEntity]
     @Environment(NoteStore.self) private var noteStore
     @Environment(NoteListPresentation.self) private var presentation
+    @Environment(\.colorScheme) private var colorScheme
     @State private var thumbnail: UIImage?
     @State private var isOpening = false
+
+    // colorScheme is the effective one, i.e. after the appearance preference's
+    // override, so the thumbnail matches the tile it sits on
+    private var interfaceStyle: UIUserInterfaceStyle {
+        colorScheme == .dark ? .dark : .light
+    }
+
+    private var thumbnailKey: String {
+        ThumbnailCache.key(for: entry, style: interfaceStyle)
+    }
 
     var body: some View {
         Button(action: openCanvas, label: {
@@ -31,8 +42,8 @@ struct NoteThumbnailView: View {
         })
         .accessibilityLabel(Self.accessibilityLabel(updatedDate: entry.updatedDate,
                                                     tagNames: tags.map(\.name)))
-        .task(id: entry.updatedDate) {
-            let key = ThumbnailCache.key(for: entry)
+        .task(id: thumbnailKey) {
+            let key = thumbnailKey
             if let cached = ThumbnailCache.shared.cached(key: key),
                noteStore.validMetadata(for: entry) != nil {
                 thumbnail = cached
@@ -43,7 +54,9 @@ struct NoteThumbnailView: View {
             // appearance retries.
             guard let note = await noteStore.loadNote(entry) else { return }
             guard !Task.isCancelled else { return }
-            thumbnail = await ThumbnailCache.shared.thumbnail(for: note.entity.drawing, key: key)
+            thumbnail = await ThumbnailCache.shared.thumbnail(for: note.entity.drawing,
+                                                              key: key,
+                                                              style: interfaceStyle)
         }
     }
 

--- a/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
+++ b/PiecesOfPaper/View/NoteList/ThumbnailCache.swift
@@ -3,22 +3,24 @@ import PencilKit
 
 /// Renders note thumbnails asynchronously and caches them.
 /// The key is derivable from a NoteIndexEntry alone, so a cache hit needs no
-/// document open; it includes updatedDate, so an edited note re-renders, and
-/// uses the file name (stable across archive/unarchive moves) instead of the
-/// entity id, which is unknown before the document is opened.
+/// document open; it includes updatedDate, so an edited note re-renders, the
+/// interface style, so switching appearance re-renders instead of reusing ink
+/// adapted for the other one, and uses the file name (stable across
+/// archive/unarchive moves) instead of the entity id, which is unknown before
+/// the document is opened.
 final class ThumbnailCache {
     static let shared = ThumbnailCache()
     private let cache = NSCache<NSString, UIImage>()
 
-    static func key(for entry: NoteIndexEntry) -> String {
-        "\(entry.fileURL.lastPathComponent)-\(entry.updatedDate.timeIntervalSince1970)"
+    static func key(for entry: NoteIndexEntry, style: UIUserInterfaceStyle) -> String {
+        "\(entry.fileURL.lastPathComponent)-\(entry.updatedDate.timeIntervalSince1970)-\(style.rawValue)"
     }
 
     func cached(key: String) -> UIImage? {
         cache.object(forKey: key as NSString)
     }
 
-    func thumbnail(for drawing: PKDrawing, key: String) async -> UIImage {
+    func thumbnail(for drawing: PKDrawing, key: String, style: UIUserInterfaceStyle) async -> UIImage {
         if let cached = cached(key: key) {
             return cached
         }
@@ -27,7 +29,7 @@ final class ThumbnailCache {
         // Not Task.detached: rendering PKDrawing off the main thread breaks
         // PKCanvasView drawing process-wide on device (#187).
         let image = await MainActor.run {
-            drawing.image(from: drawing.bounds, scale: 1.0)
+            drawing.image(scale: 1.0, style: style)
         }
         cache.setObject(image, forKey: key as NSString)
         return image

--- a/PiecesOfPaper/View/Root/RootSplitView.swift
+++ b/PiecesOfPaper/View/Root/RootSplitView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct RootSplitView: View {
     @State private var noteStore = NoteStore()
     @State private var tagStore = TagStore()
-    @State private var preferenceStore = PreferenceStore()
+    @Environment(PreferenceStore.self) private var preferenceStore
     @State private var selection: Page? = .inbox
     @Environment(\.scenePhase) private var scenePhase
     @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
@@ -91,7 +91,6 @@ struct RootSplitView: View {
         }
         .environment(noteStore)
         .environment(tagStore)
-        .environment(preferenceStore)
     }
 
     private var sideBarList: some View {
@@ -147,4 +146,5 @@ struct RootSplitView: View {
 
 #Preview {
     RootSplitView()
+        .environment(PreferenceStore())
 }

--- a/PiecesOfPaper/View/Root/RootSplitView.swift
+++ b/PiecesOfPaper/View/Root/RootSplitView.swift
@@ -91,6 +91,10 @@ struct RootSplitView: View {
         }
         .environment(noteStore)
         .environment(tagStore)
+        // Read here, not in the App's Scene body: preferredColorScheme is a
+        // preference that flows up to the scene host, and reading the store from
+        // a View body is what guarantees Observation re-evaluates it
+        .preferredColorScheme(preferenceStore.appearanceMode.colorScheme)
     }
 
     private var sideBarList: some View {

--- a/PiecesOfPaper/View/Setting/SettingView.swift
+++ b/PiecesOfPaper/View/Setting/SettingView.swift
@@ -18,6 +18,16 @@ struct SettingView: View {
                 Toggle(isOn: $preferenceStore.enabledInfiniteScroll) {
                     Label("Infinite Scroll", systemImage: "scroll")
                 }
+                // Not .segmented as elsewhere in the app: that style drops the
+                // label, breaking the Label(_:systemImage:) shape of the rows above
+                Picker(selection: $preferenceStore.appearanceMode) {
+                    ForEach(AppearanceMode.allCases) { mode in
+                        Text(mode.label)
+                            .tag(mode)
+                    }
+                } label: {
+                    Label("Appearance", systemImage: "circle.lefthalf.filled")
+                }
             }
             Section(header: Text("About")) {
                 if let url = repositoryUrl {

--- a/PiecesOfPaper/View/Tag/Tag.swift
+++ b/PiecesOfPaper/View/Tag/Tag.swift
@@ -13,7 +13,12 @@ struct Tag: View {
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
+        // Tag colors are RGBA frozen under a light trait and fill at 70%, so on a
+        // dark background they darken and lose contrast against the label. The
+        // chip keeps a light base in both appearances rather than adapting.
+        .foregroundStyle(.black)
         .background(entity.color.swiftUIColor)
+        .background(.white)
         .cornerRadius(4)
     }
 }

--- a/PiecesOfPaper/View/Tutorial/TutorialView.swift
+++ b/PiecesOfPaper/View/Tutorial/TutorialView.swift
@@ -115,7 +115,7 @@ struct TutorialView: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.yellow.opacity(0.15), in: RoundedRectangle(cornerRadius: 12))
+        .background(Color.calloutBackground, in: RoundedRectangle(cornerRadius: 12))
     }
 
     private var faq: some View {

--- a/PiecesOfPaperTests/AppearanceModeTests.swift
+++ b/PiecesOfPaperTests/AppearanceModeTests.swift
@@ -1,0 +1,23 @@
+import Testing
+import SwiftUI
+@testable import Pieces_of_Paper
+
+struct AppearanceModeTests {
+    // The raw values are the UserDefaults payload: renaming a case silently
+    // resets every existing choice to .system
+    @Test func test_rawValues_areStable() {
+        #expect(AppearanceMode.system.rawValue == "system")
+        #expect(AppearanceMode.light.rawValue == "light")
+        #expect(AppearanceMode.dark.rawValue == "dark")
+    }
+
+    @Test func test_colorScheme_isNilOnlyForSystem() {
+        #expect(AppearanceMode.system.colorScheme == nil)
+        #expect(AppearanceMode.light.colorScheme == .light)
+        #expect(AppearanceMode.dark.colorScheme == .dark)
+    }
+
+    @Test func test_allCases_areOfferedInSystemLightDarkOrder() {
+        #expect(AppearanceMode.allCases == [.system, .light, .dark])
+    }
+}

--- a/PiecesOfPaperTests/NoteShareItemSourceTests.swift
+++ b/PiecesOfPaperTests/NoteShareItemSourceTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import Foundation
+@testable import Pieces_of_Paper
+
+struct NoteShareItemSourceTests {
+    private let locale = Locale(identifier: "en_US")
+
+    // The share sheet header is built from this, so it must name the note rather
+    // than describe the file type
+    @Test func test_title_namesTheNoteWithItsDate() {
+        let updatedDate = Date(timeIntervalSince1970: 1_000_000)
+        let title = NoteShareItemSource.title(updatedDate: updatedDate, locale: locale)
+
+        let expectedDate = updatedDate.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened).locale(locale)
+        )
+        #expect(title == "Note, \(expectedDate)")
+    }
+
+    @Test func test_title_distinguishesNotesByDate() {
+        let first = NoteShareItemSource.title(updatedDate: Date(timeIntervalSince1970: 1_000_000), locale: locale)
+        let second = NoteShareItemSource.title(updatedDate: Date(timeIntervalSince1970: 2_000_000), locale: locale)
+        #expect(first != second)
+    }
+}

--- a/PiecesOfPaperTests/PKDrawingShareImageTests.swift
+++ b/PiecesOfPaperTests/PKDrawingShareImageTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import UIKit
+import PencilKit
+@testable import Pieces_of_Paper
+
+@MainActor
+struct PKDrawingShareImageTests {
+    // The share sheet hands this UIImage straight to another app, so a transparent
+    // background is composited on black by any viewer in dark mode and swallows the
+    // dark ink the light trait deliberately preserves
+    @Test func test_lightModeImage_isFullyOpaque() throws {
+        let pixels = try Self.rgbaPixels(of: PKDrawing.stub().lightModeImage(scale: 1))
+        #expect(pixels.lazy.map(\.alpha).min() == 255)
+    }
+
+    @Test func test_lightModeImage_keepsTheInkVisible() throws {
+        let pixels = try Self.rgbaPixels(of: PKDrawing.stub().lightModeImage(scale: 1))
+        #expect(pixels.contains { $0.alpha == 255 && $0.red < 128 })
+    }
+
+    private struct Pixel {
+        let red: UInt8
+        let alpha: UInt8
+    }
+
+    /// Draws the image into a context that starts as transparent black, so any area
+    /// the image does not cover opaquely comes back with alpha below 255.
+    private static func rgbaPixels(of image: UIImage) throws -> [Pixel] {
+        let cgImage = try #require(image.cgImage)
+        let width = cgImage.width
+        let height = cgImage.height
+        var buffer = [UInt8](repeating: 0, count: width * height * 4)
+        let context = try #require(CGContext(data: &buffer,
+                                             width: width,
+                                             height: height,
+                                             bitsPerComponent: 8,
+                                             bytesPerRow: width * 4,
+                                             space: CGColorSpaceCreateDeviceRGB(),
+                                             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return stride(from: 0, to: buffer.count, by: 4).map {
+            Pixel(red: buffer[$0], alpha: buffer[$0 + 3])
+        }
+    }
+}

--- a/PiecesOfPaperTests/PreferenceStoreTests.swift
+++ b/PiecesOfPaperTests/PreferenceStoreTests.swift
@@ -8,14 +8,17 @@ struct PreferenceStoreTests {
         mock.enablediCloud = true
         mock.enabledAutoSave = false
         mock.enabledInfiniteScroll = false
+        mock.appearanceMode = .dark
 
         let store = PreferenceStore(repository: mock)
         #expect(store.enablediCloud)
         #expect(!store.enabledAutoSave)
         #expect(!store.enabledInfiniteScroll)
+        #expect(store.appearanceMode == .dark)
         #expect(mock.setEnablediCloudCalls.isEmpty)
         #expect(mock.setEnabledAutoSaveCalls.isEmpty)
         #expect(mock.setEnabledInfiniteScrollCalls.isEmpty)
+        #expect(mock.setAppearanceModeCalls.isEmpty)
     }
 
     @Test func test_enablediCloud_persistsOnChange() {
@@ -40,6 +43,14 @@ struct PreferenceStoreTests {
         store.enabledInfiniteScroll = false
         #expect(mock.setEnabledInfiniteScrollCalls == [false])
         #expect(!mock.getEnabledInfiniteScroll())
+    }
+
+    @Test func test_appearanceMode_persistsOnChange() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        store.appearanceMode = .light
+        #expect(mock.setAppearanceModeCalls == [.light])
+        #expect(mock.getAppearanceMode() == .light)
     }
 
     @Test func test_cloudAvailability_isUserDisabled_wheniCloudToggleOff() {

--- a/PiecesOfPaperTests/RepositoryMocks.swift
+++ b/PiecesOfPaperTests/RepositoryMocks.swift
@@ -222,10 +222,12 @@ final class PreferenceRepositoryMock: PreferenceRepositoryProtocol {
     var enablediCloud = false
     var enabledAutoSave = true
     var enabledInfiniteScroll = true
+    var appearanceMode: AppearanceMode = .system
     var listOrders: [String: ListOrder] = [:]
     private(set) var setEnablediCloudCalls: [Bool] = []
     private(set) var setEnabledAutoSaveCalls: [Bool] = []
     private(set) var setEnabledInfiniteScrollCalls: [Bool] = []
+    private(set) var setAppearanceModeCalls: [AppearanceMode] = []
     private(set) var setListOrderCalls: [(directoryName: String, listOrder: ListOrder)] = []
 
     func getEnablediCloud() -> Bool { enablediCloud }
@@ -247,6 +249,13 @@ final class PreferenceRepositoryMock: PreferenceRepositoryProtocol {
     func setEnabledInfiniteScroll(_ value: Bool) {
         enabledInfiniteScroll = value
         setEnabledInfiniteScrollCalls.append(value)
+    }
+
+    func getAppearanceMode() -> AppearanceMode { appearanceMode }
+
+    func setAppearanceMode(_ value: AppearanceMode) {
+        appearanceMode = value
+        setAppearanceModeCalls.append(value)
     }
 
     func getListOrder(directoryName: String) -> ListOrder {

--- a/PiecesOfPaperTests/ThumbnailCacheTests.swift
+++ b/PiecesOfPaperTests/ThumbnailCacheTests.swift
@@ -1,0 +1,22 @@
+import Testing
+import UIKit
+@testable import Pieces_of_Paper
+
+struct ThumbnailCacheTests {
+    private let entry = NoteIndexEntry(fileURL: URL(fileURLWithPath: "/notes/2024-01-02-03-04-051234.pop"),
+                                       creationDate: nil,
+                                       contentModificationDate: Date(timeIntervalSince1970: 2_000))
+
+    // PencilKit adapts ink to the interface style, so a thumbnail rendered under
+    // one appearance must not be served under the other
+    @Test func test_key_differsByInterfaceStyle() {
+        #expect(ThumbnailCache.key(for: entry, style: .light) != ThumbnailCache.key(for: entry, style: .dark))
+    }
+
+    @Test func test_key_differsWhenTheNoteIsEdited() {
+        let edited = NoteIndexEntry(fileURL: entry.fileURL,
+                                    createdDate: entry.createdDate,
+                                    updatedDate: entry.updatedDate.addingTimeInterval(1))
+        #expect(ThumbnailCache.key(for: entry, style: .light) != ThumbnailCache.key(for: edited, style: .light))
+    }
+}

--- a/docs/progress/2026-07-26-appearance-setting.md
+++ b/docs/progress/2026-07-26-appearance-setting.md
@@ -4,3 +4,6 @@
   - `ThumbnailCache` renders under an explicit interface style and keys on it; the previous ambient-trait render could put dark ink on a dark tile once the app appearance can differ from the system's
   - Tag chips pinned to a light base with black text, and the tutorial callout given a dynamic colour via the new `View/Color+App.swift`
   - The shared note image now fills white before drawing, like the QuickLook and Thumbnail extensions already did: `PKDrawing.image` leaves the background transparent, so a viewer in dark mode composited it on black and the dark ink disappeared
+- [x] Name the note in the share sheet header instead of showing "PNG image" (issue #270, PR #264)
+  - The image is wrapped in a `NoteShareItemSource`; metadata used to hang off a second item whose `itemForActivityType` returned nil, so iOS described the remaining bare `UIImage` by its type
+  - `LPLinkMetadata.iconProvider`, not `imageProvider`, is what puts the drawing in the header. The iPad popover form of the sheet shows no icon either way

--- a/docs/progress/2026-07-26-appearance-setting.md
+++ b/docs/progress/2026-07-26-appearance-setting.md
@@ -1,0 +1,5 @@
+- [x] Add an in-app appearance setting: System / Light / Dark (issue #262, PR #264)
+  - `PreferenceStore` ownership moved up to `PiecesOfPaperApp` as `@State`, so all scenes share one instance instead of each iPad window holding its own
+  - `.preferredColorScheme` is attached in `RootSplitView`, not the App's `Scene` body: reading the store from a `View` body is what guarantees Observation re-evaluates it
+  - `ThumbnailCache` renders under an explicit interface style and keys on it; the previous ambient-trait render could put dark ink on a dark tile once the app appearance can differ from the system's
+  - Tag chips pinned to a light base with black text, and the tutorial callout given a dynamic colour via the new `View/Color+App.swift`

--- a/docs/progress/2026-07-26-appearance-setting.md
+++ b/docs/progress/2026-07-26-appearance-setting.md
@@ -3,3 +3,4 @@
   - `.preferredColorScheme` is attached in `RootSplitView`, not the App's `Scene` body: reading the store from a `View` body is what guarantees Observation re-evaluates it
   - `ThumbnailCache` renders under an explicit interface style and keys on it; the previous ambient-trait render could put dark ink on a dark tile once the app appearance can differ from the system's
   - Tag chips pinned to a light base with black text, and the tutorial callout given a dynamic colour via the new `View/Color+App.swift`
+  - The shared note image now fills white before drawing, like the QuickLook and Thumbnail extensions already did: `PKDrawing.image` leaves the background transparent, so a viewer in dark mode composited it on black and the dark ink disappeared


### PR DESCRIPTION
Closes #262
Closes #270

Adds a **System / Light / Dark** preference to the Setting screen and applies it to the
whole app. With Dark selected the canvas "paper" goes dark too, keeping PencilKit's
default behaviour of re-rendering dark ink as light on a dark background. The share
image and the QuickLook / Thumbnail extensions still render dark ink on white, which is
deliberate (see the comment in `ThumbnailExtension/ThumbnailProvider.swift`).

## What changed

### The preference itself

- New `PiecesOfPaper/Model/AppearanceMode.swift` — `String`-backed enum, `CaseIterable`,
  `Identifiable`, with `colorScheme: ColorScheme?` (`nil` for `.system`). The case names
  are the persisted raw values, so the display text lives in a separate `label`.
- `PreferenceRepository` stores the raw value under `appearance_mode`, restoring via
  `AppearanceMode(rawValue:) ?? .system`. The Bool keys' `*_disabled` inversion exists only
  to make UserDefaults' `false` default mean "enabled"; an absent string already means
  `.system`, so it is not used here.
- `PreferenceStore.appearanceMode` follows the existing `didSet` write-through pattern and
  is read once in `init`, keeping the no-re-persist-on-init invariant.
- `SettingView` gains a fourth Preference row. It is a menu-style `Picker`, not the
  `.segmented` style used in `ListOrderSettingView` — segmented drops the label and would
  break the `Label(_:systemImage:)` shape of the three rows above it.

### Scene ownership (behaviour change)

`UIApplicationSupportsMultipleScenes` is `true`, and `PreferenceStore` was a `@State` inside
`RootSplitView`, so two iPad windows each got their own instance and a preference changed in
one would not reach the other until relaunch. Ownership moves up to `PiecesOfPaperApp` as
`@State` (shared by all scenes) and is injected from `WindowGroup`; `RootSplitView` now reads
it via `@Environment`. `NoteStore` and `TagStore` stay per-scene — unchanged, out of scope here.

`.preferredColorScheme` is attached in `RootSplitView`'s modifier chain rather than in the
App's `Scene` body: it is a preference that flows up to the scene host, and reading
`appearanceMode` from a `View` body is what guarantees Observation re-evaluates it.

No `UIUserInterfaceStyle` key is added to `Info.plist` — that would pin the app and defeat
`.system`.

### Thumbnails (pulled in from the issue's "Known limitation")

`ThumbnailCache` rendered `drawing.image(...)` inside `MainActor.run`, outside any view-update
trait context, so `UITraitCollection.current` did not track the window's appearance override,
while the tile background (`secondarySystemBackground`) did. With an app-level appearance that
could put dark ink on a dark tile, so this is fixed here rather than deferred:

- `PKDrawing.lightModeImage(scale:)` is generalised into `image(scale:style:)`, which the
  share-sheet path calls with `.light`.
- `ThumbnailCache.key(for:style:)` includes the interface style, and `thumbnail(for:key:style:)`
  renders under that explicit style. `NoteThumbnailView` reads `@Environment(\.colorScheme)` and
  uses the key as its `.task(id:)`, so switching appearance re-renders instead of serving ink
  adapted for the other one. The `#187` constraint (no off-main `PKDrawing.image`) is preserved.

### The shared image is now opaque white

Reported against this branch: with Dark selected, sharing a note produced an all-black image.
Forcing the light trait was never enough on its own — `PKDrawing.image` leaves the background
transparent, and any viewer in dark mode composites that on black, so the dark ink the light
trait preserves disappears into it. `lightModeImage(scale:)` now fills white and draws the ink
on top, which is exactly what `ThumbnailExtension/ThumbnailProvider.swift:36` already did for
QuickLook. The bug predates this branch — it was reachable whenever the OS was in dark mode —
but the in-app setting is what made it easy to hit.

### The share sheet names the note (#270)

Also reported against this branch: the share sheet header read "PNG image". The wrapper was
passing two items — the bare `UIImage`, and its own `Coordinator`, which supplied
`LPLinkMetadata` but returned `nil` from `itemForActivityType` and so contributed no item.
The header was therefore built from the image, which carries no metadata, and iOS named the
type instead.

A new `NoteShareItemSource` supplies the image and its metadata together, and the
metadata-only `Coordinator` is gone. The title follows the naming the grid already uses under
VoiceOver — notes have no title, so the update date distinguishes them:

```
Note, Jul 26, 2026 at 13:40
```

`LPLinkMetadata.iconProvider` (not `imageProvider`, which is the large link preview) puts the
drawing in the header. Both share entry points — canvas toolbar and note list context menu —
go through the same type.

### Dark-mode contrast (also pulled in from the issue's Out of scope)

- `Tag.swift`: tag colours are RGBA frozen under a light trait and fill at 70%, so on a dark
  background they darkened and lost contrast against the `.primary` (white) label. The chip is
  now pinned to a light base with black text, so it looks the same in both appearances.
- New `PiecesOfPaper/View/Color+App.swift` holds `calloutBackground` — `Assets.xcassets` has no
  colour sets, so the light/dark pair is built with `UIColor(dynamicProvider:)`.
  `TutorialView`'s Important Notes block uses it instead of a flat `.yellow.opacity(0.15)`,
  which all but vanishes on black.
- `ListOrderSettingView`'s `Color.gray.opacity(0.2)` is left alone: 20% grey over a dark
  background still reads as the slightly lighter panel it is meant to be.

## Tests

182 tests / 29 suites pass (was 176 / 26).

- `PreferenceStoreTests.test_init_readsValuesWithoutRePersisting` extended, and
  `test_appearanceMode_persistsOnChange` added.
- New `AppearanceModeTests` pins the raw values — they are the UserDefaults payload, so renaming
  a case would silently reset every stored choice to `.system`.
- New `ThumbnailCacheTests` asserts the key differs by interface style.
- New `PKDrawingShareImageTests` scans every pixel of the shared image: none may be
  less than fully opaque, and some must still be dark, so a future white fill cannot
  quietly paint over the ink. Confirmed to fail before the fix
  (`min alpha → 0`) and pass after.
- New `NoteShareItemSourceTests` covers the share title's date formatting, as
  `NoteThumbnailViewTests` does for the accessibility label.

## Simulator verification

iPad Pro 11" / iOS 26.5, on a dedicated simulator (created and deleted for this run).

- Dark selected with the OS in Light: sidebar, note list, Setting, Tag List and Quick Tutorial
  all dark; the fullscreen canvas is dark too, so `preferredColorScheme` does reach the
  `fullScreenCover` and `PKCanvasView`'s background follows the trait.
- Picking Light in the Setting picker flips the whole app immediately; after terminate and
  relaunch with the OS switched to Dark, the app comes back Light.
- Picking System with the OS dark turns the app dark, and toggling the OS to light flips it
  live with no relaunch.
- Note thumbnails are legible in both: dark ink on a light tile in Light, light ink on a dark
  tile in Dark, re-rendered on switch.
- Tag chips read as black text on pastel in Dark; the Important Notes callout is a visible warm
  panel rather than disappearing.
- Sharing from the note list context menu shows "Note, Jul 26, 2026 at 13:40" as the header,
  not "PNG image". On an iPhone 16 / iOS 26.5 simulator the header also shows the drawing —
  on white, which is the white fill above seen end to end. The iPad popover form of the sheet
  renders the title without an icon regardless of the metadata.

Not verified: two iPad scenes side by side. There is no command-line way to open a second
window, so the shared-store behaviour rests on `@State` on `App` semantics and still needs a
manual check.

## Still needs a physical iPad (CLAUDE.md "Verification", #187)

- Dark: the default pen is `PKInkingTool(.pen, color: .black, width: 1)` — confirm the ink is
  visible on the dark canvas.
- The `PKToolPicker` palette renders correctly and its colours produce visible ink.
- A note drawn in Dark still exports as dark ink on white through the share sheet and the
  Files-app QuickLook thumbnail. The white fill above is covered by a unit test, but the
  round trip through a real share target is not.
- Draw, switch appearance, draw again, background/foreground — strokes keep registering.

If any of those fail the fixes are `toolPicker.colorUserInterfaceStyle`,
`PKInkingTool.convertColor(_:from:to:)` for the default pen, and/or
`canvasView.backgroundColor = .systemBackground`. None are included pre-emptively.
