### PR TITLE
Route the canvas preference reads through PreferenceStore

### DIFF
--- a/PiecesOfPaper/View/Canvas/CanvasView.swift
+++ b/PiecesOfPaper/View/Canvas/CanvasView.swift
@@ -5,6 +5,7 @@ import StoreKit
 struct CanvasView: View {
     @State private var note: NoteData
     @Environment(NoteStore.self) private var noteStore
+    @Environment(PreferenceStore.self) private var preferenceStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.displayScale) private var displayScale
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -86,6 +87,10 @@ struct CanvasView: View {
         PKCanvasViewWrapper(canvasView: $canvasView,
                             toolPicker: $toolPicker,
                             isToolPickerVisible: !hideExceptPaper,
+                            // The store is captured explicitly: without a capture list these
+                            // close over the whole view, which reads @Environment outside body
+                            isAutoSaveEnabled: { [preferenceStore] in preferenceStore.enabledAutoSave },
+                            isInfiniteScrollEnabled: { [preferenceStore] in preferenceStore.enabledInfiniteScroll },
                             saveAction: { save(drawing: $0) },
                             onToggleUI: { toggleUIVisibility() })
         .onAppear {
@@ -271,5 +276,6 @@ struct CanvasView: View {
 #Preview {
     CanvasView(note: NoteData.createTestData())
         .environment(NoteStore())
+        .environment(PreferenceStore())
 }
 #endif

--- a/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
+++ b/PiecesOfPaper/View/Canvas/PKCanvasViewWrapper.swift
@@ -5,6 +5,11 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
     @Binding private var canvasView: PKCanvasView
     @Binding private var toolPicker: PKToolPicker
     private let isToolPickerVisible: Bool
+    // Closures rather than Bool: updateUIView is empty, so Coordinator.parent is
+    // frozen at the value makeCoordinator() captured, and a copied flag would go
+    // stale when the setting changes while the canvas is open
+    private let isAutoSaveEnabled: () -> Bool
+    private let isInfiniteScrollEnabled: () -> Bool
     private let saveAction: (PKDrawing) -> Void
     private let onToggleUI: (() -> Void)?
     private var defaultTool = PKInkingTool(.pen, color: .black, width: 1)
@@ -14,11 +19,15 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
     init(canvasView: Binding<PKCanvasView>,
          toolPicker: Binding<PKToolPicker>,
          isToolPickerVisible: Bool,
+         isAutoSaveEnabled: @escaping () -> Bool,
+         isInfiniteScrollEnabled: @escaping () -> Bool,
          saveAction: @escaping (PKDrawing) -> Void,
          onToggleUI: (() -> Void)? = nil) {
         self._canvasView = canvasView
         self._toolPicker = toolPicker
         self.isToolPickerVisible = isToolPickerVisible
+        self.isAutoSaveEnabled = isAutoSaveEnabled
+        self.isInfiniteScrollEnabled = isInfiniteScrollEnabled
         self.saveAction = saveAction
         self.onToggleUI = onToggleUI
         self.previousTool = defaultTool
@@ -87,16 +96,21 @@ struct PKCanvasViewWrapper: UIViewRepresentable {
 
 // MARK: - PKCanvasViewDelegate
 extension PKCanvasViewWrapper.Coordinator: PKCanvasViewDelegate {
+    // Both preference reads live here rather than in the helper below:
+    // PKCanvasViewDelegate is NS_SWIFT_UI_ACTOR, so this witness is MainActor
+    // isolated and may touch the @MainActor PreferenceStore; the private helper
+    // is not a witness and inherits no isolation
     func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
-        updateContentSizeIfNeeded(canvasView)
+        if parent.isInfiniteScrollEnabled() {
+            updateContentSizeIfNeeded(canvasView)
+        }
 
-        guard PreferenceRepository().getEnabledAutoSave() else { return }
+        guard parent.isAutoSaveEnabled() else { return }
         parent.saveAction(canvasView.drawing)
     }
 
     private func updateContentSizeIfNeeded(_ canvasView: PKCanvasView) {
-        guard !canvasView.drawing.bounds.isNull,
-              PreferenceRepository().getEnabledInfiniteScroll() else { return }
+        guard !canvasView.drawing.bounds.isNull else { return }
         let drawingWidth = canvasView.drawing.bounds.maxX
         if canvasView.contentSize.width * 9 / 10 < drawingWidth {
             canvasView.contentSize.width += canvasView.frame.width
@@ -161,5 +175,7 @@ extension PKCanvasViewWrapper.Coordinator: UIScrollViewDelegate {
     PKCanvasViewWrapper(canvasView: $canvasView,
                         toolPicker: $toolPicker,
                         isToolPickerVisible: true,
+                        isAutoSaveEnabled: { true },
+                        isInfiniteScrollEnabled: { true },
                         saveAction: { _ in })
 }

--- a/PiecesOfPaperTests/PKCanvasViewWrapperTests.swift
+++ b/PiecesOfPaperTests/PKCanvasViewWrapperTests.swift
@@ -1,0 +1,132 @@
+import PencilKit
+import SwiftUI
+import Testing
+@testable import Pieces_of_Paper
+
+@MainActor
+struct PKCanvasViewWrapperTests {
+    private final class SaveRecorder {
+        private(set) var drawings: [PKDrawing] = []
+
+        func record(_ drawing: PKDrawing) {
+            drawings.append(drawing)
+        }
+    }
+
+    private func makeCanvas(frame: CGRect = CGRect(x: 0, y: 0, width: 200, height: 300)) -> PKCanvasView {
+        let canvas = PKCanvasView(frame: frame)
+        canvas.drawing = .stub()
+        // Sized to the drawing so it sits past the 90% threshold the wrapper grows on
+        canvas.contentSize = CGSize(width: canvas.drawing.bounds.maxX,
+                                    height: canvas.drawing.bounds.maxY)
+        return canvas
+    }
+
+    private func makeCoordinator(store: PreferenceStore,
+                                 canvas: PKCanvasView,
+                                 recorder: SaveRecorder) -> PKCanvasViewWrapper.Coordinator {
+        PKCanvasViewWrapper(canvasView: .constant(canvas),
+                            toolPicker: .constant(PKToolPicker()),
+                            isToolPickerVisible: false,
+                            isAutoSaveEnabled: { store.enabledAutoSave },
+                            isInfiniteScrollEnabled: { store.enabledInfiniteScroll },
+                            saveAction: { recorder.record($0) })
+            .makeCoordinator()
+    }
+
+    @Test func test_drawingDidChange_savesWhenAutoSaveIsEnabled() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = true
+        mock.enabledInfiniteScroll = false
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let recorder = SaveRecorder()
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: recorder)
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(recorder.drawings == [canvas.drawing])
+    }
+
+    @Test func test_drawingDidChange_doesNotSaveWhenAutoSaveIsDisabled() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = false
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let recorder = SaveRecorder()
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: recorder)
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(recorder.drawings.isEmpty)
+    }
+
+    // The coordinator is built once and never rebuilt, so a copied Bool would
+    // keep the canvas on the value the setting had when it opened
+    @Test func test_drawingDidChange_followsAutoSaveChangedAfterTheCoordinatorWasMade() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = false
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let recorder = SaveRecorder()
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: recorder)
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+        #expect(recorder.drawings.isEmpty)
+
+        store.enabledAutoSave = true
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(recorder.drawings == [canvas.drawing])
+    }
+
+    @Test func test_drawingDidChange_growsContentSizeWhenInfiniteScrollIsEnabled() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = true
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let expected = CGSize(width: canvas.contentSize.width + canvas.frame.width,
+                              height: canvas.contentSize.height + canvas.frame.height)
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: SaveRecorder())
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(canvas.contentSize == expected)
+    }
+
+    @Test func test_drawingDidChange_leavesContentSizeWhenInfiniteScrollIsDisabled() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = false
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let contentSize = canvas.contentSize
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: SaveRecorder())
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(canvas.contentSize == contentSize)
+    }
+
+    @Test func test_drawingDidChange_followsInfiniteScrollChangedAfterTheCoordinatorWasMade() {
+        let mock = PreferenceRepositoryMock()
+        mock.enabledAutoSave = false
+        mock.enabledInfiniteScroll = false
+        let store = PreferenceStore(repository: mock)
+        let canvas = makeCanvas()
+        let contentSize = canvas.contentSize
+        let coordinator = makeCoordinator(store: store, canvas: canvas, recorder: SaveRecorder())
+
+        coordinator.canvasViewDrawingDidChange(canvas)
+        #expect(canvas.contentSize == contentSize)
+
+        store.enabledInfiniteScroll = true
+        coordinator.canvasViewDrawingDidChange(canvas)
+
+        #expect(canvas.contentSize == CGSize(width: contentSize.width + canvas.frame.width,
+                                             height: contentSize.height + canvas.frame.height))
+    }
+}

--- a/docs/progress/2026-07-26-canvas-preference-store.md
+++ b/docs/progress/2026-07-26-canvas-preference-store.md
@@ -1,0 +1,4 @@
+- [x] Route the canvas preference reads through PreferenceStore (issue #269, PR #280)
+  - `PKCanvasViewWrapper` takes the autosave and infinite scroll flags as closures alongside `saveAction`; `CanvasView` supplies them from `@Environment(PreferenceStore.self)`, capturing the store explicitly so the read is not a frozen `@Environment` copy. Closures rather than `Bool`s because the empty `updateUIView` freezes `Coordinator.parent`
+  - `MainActor.assumeIsolated` turned out to be unnecessary: `PKCanvasViewDelegate` is `NS_SWIFT_UI_ACTOR`, so `canvasViewDrawingDidChange` is an isolated witness. Both preference reads had to move into it because the private `updateContentSizeIfNeeded` helper is not a witness and inherits no isolation
+  - First tests over the autosave gate (`PKCanvasViewWrapperTests`), including the value changing after the coordinator was made; confirmed to fail against a probe that freezes the flags at init


### PR DESCRIPTION
Closes #269

## What changes

`PKCanvasViewWrapper.Coordinator` no longer constructs `PreferenceRepository()` on every stroke change. The two flags arrive as closures alongside the existing `saveAction` / `onToggleUI`, and `CanvasView` supplies them from the `PreferenceStore` it now reads out of the environment.

- `PKCanvasViewWrapper`: new `isAutoSaveEnabled: () -> Bool` and `isInfiniteScrollEnabled: () -> Bool` init parameters. They sit before `onToggleUI` because SwiftLint's `function_default_parameter_at_end` is on.
- `CanvasView`: `@Environment(PreferenceStore.self)`, and the closures capture the store explicitly — `{ [preferenceStore] in ... }`. Without a capture list they close over the whole view, which reads `@Environment` outside body evaluation.
- Both preference reads moved up into `canvasViewDrawingDidChange`; `updateContentSizeIfNeeded` now guards only on the drawing bounds. Behaviour is unchanged — the `!bounds.isNull && infiniteScroll` conjunction is split between the caller and the guard.

Closures rather than `Bool`s because `updateUIView` is empty, so `Coordinator.parent` is frozen at whatever `makeCoordinator()` captured; a copied flag would go stale.

## Correction to the issue's premise

The issue expected this to need `MainActor.assumeIsolated` or an isolation annotation. It does not. `PKCanvasViewDelegate` is declared `NS_SWIFT_UI_ACTOR` (`PKCanvasView.h`, iOS 26.5 SDK), so `canvasViewDrawingDidChange` witnesses a `@MainActor` requirement and is inferred isolated — it may touch the `@MainActor` `PreferenceStore` directly. The private helper is *not* a witness and inherits no isolation, which is why both reads had to move into the delegate method rather than stay in the helper.

## Tests

`PiecesOfPaperTests/PKCanvasViewWrapperTests.swift` — the first test coverage of the autosave gate. The Coordinator is built directly and `canvasViewDrawingDidChange` called on it, so no PencilKit rendering is involved. Six tests: autosave on/off, infinite scroll on/off, and one per flag for the value changing *after* the coordinator was made.

The two live-read tests were confirmed to have detection power: with a `TEMP-VERIFY` probe freezing both closures at init (the naive copied-`Bool` implementation), exactly those two fail and the other four pass. Probe reverted with `git checkout --`; the test run below is on the reverted tree.

## Verification

`swiftlint` clean on all three touched files. `✔ Test run with 188 tests in 30 suites passed`, run after merging `origin/main` (#278); the six new test names appear in the log.

Simulator (iPad Pro 11-inch, iOS 26.5, dedicated device created for this run and deleted after), driven by idb:

- The canvas opens, which is itself the check that `@Environment(PreferenceStore.self)` resolves inside the `fullScreenCover` — an unresolved value would trap at body evaluation.
- Auto Save on: one stroke, and the note appears in `InboxFolder` with the thumbnail rendering the stroke in the list.
- Auto Save off: another stroke leaves the `.pop` file byte-identical (same md5, same mtime), and Done raises the "Save changes?" alert. Tapping Save writes the file.
- Auto Save back on: drawing writes the file again.

Not verified from the Simulator, and covered only by the unit tests:

- **`contentSize` growth.** The canvas exposes no scroll geometry in the accessibility tree, and idb cannot inject the two-finger drag that would scroll it.
- **Changing a preference while the canvas stays open.** Setting sits behind the `fullScreenCover`, so it is unreachable in a single window. The real path is two iPad windows sharing the one `PreferenceStore` (`UIApplicationSupportsMultipleScenes` is on, and #264 moved store ownership to the App for exactly that reason) — idb cannot create the second scene.

## Still needs a device

Not run on a physical iPad. The issue waives the `CLAUDE.md` canvas rule on the grounds that this touches no `PKDrawing.image` and adds no off-main rendering, which holds — but it does change the drawing hot path, so flagging it rather than silently skipping.
