### PR TITLE
Document idb timing and out-of-process UI limits in SIMULATOR_E2E

### DIFF
--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -60,6 +60,15 @@ coordinate values).
 | `idb ui describe-all --udid $UDID` | Accessibility tree as JSON |
 | `xcrun simctl io $UDID screenshot out.png` | Screenshot (`idb screenshot` can fail with "No Image available to encode") |
 
+Wait 3–4 seconds between an action and the screenshot or `describe-all` that checks it.
+A presentation started from a SwiftUI update pass is deferred a runloop turn and then
+animates, so a screenshot taken immediately shows the *previous* state — which reads as
+"the tap did nothing" and sends you diagnosing hit-testing that is not broken.
+
+Out-of-process UI is invisible to `describe-all`: `UIActivityViewController`'s rows are
+served by a remote view service and return nothing, so the share sheet is asserted from a
+screenshot and driven by tapping computed coordinates (screenshot pixels ÷ device scale).
+
 Assertions that need no screenshot diffing:
 
 - **Strokes**: `describe-all` lists each PencilKit stroke as an element with


### PR DESCRIPTION
Closes #288

Docs only. Adds two paragraphs to the "Operating and asserting" section of `docs/SIMULATOR_E2E.md`, both learned while verifying #268 (PR #282):

- Wait 3–4 seconds between an action and the screenshot or `describe-all` that checks it. A presentation started from a SwiftUI update pass is deferred a runloop turn and then animates, so an immediate screenshot shows the previous state and reads as "the tap did nothing".
- `describe-all` cannot see out-of-process UI. `UIActivityViewController`'s rows come from a remote view service, so the share sheet is asserted from a screenshot and driven by tapping computed coordinates.

No progress fragment: this is a docs-only follow-up to PR #282, whose fragment already covers the share sheet work.
