### PR TITLE
Document container re-seeding and per-note popover capture

### DIFF
--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -89,6 +89,12 @@ simulator: parallel sessions install their own builds over each other and the da
 container can be replaced under you. Run verification on a dedicated simulator
 (`xcrun simctl create`, or any device no other session uses), not the shared default.
 
+Your own re-installs swap it too, with no other session involved: the path
+`get_app_container` returns after `simctl install` differs from the one it returned
+before, and the earlier seed belongs to the old container. Seed *after* the final
+install and re-query the path every time — otherwise the app launches with an empty
+note list, which reads as a load failure rather than a missing seed.
+
 ## Opening a note file via URL (onOpenURL path)
 
 ```sh
@@ -99,6 +105,12 @@ delivers the file URL to the app's `onOpenURL` handler — both while the app is
 (canvas swap) and from a cold launch — without automating the Files app. It cannot
 exercise the security-scope path (files outside the app container); that still needs a
 device and the real Files app. Background: PR #208.
+
+Because the control panel is tappable at launch, this also reaches the canvas's own UI
+for a *chosen* note: `openurl` a seeded note, then `idb ui tap` the Note Information
+button to capture that note's info popover. The four states of issue #267 — no tags,
+tags overflowing the row, a long file name, and the DEBUG ID row — were verified this
+way, with no gesture injection.
 
 ## Limitations
 

--- a/docs/progress/2026-07-26-simulator-e2e-seeding-notes.md
+++ b/docs/progress/2026-07-26-simulator-e2e-seeding-notes.md
@@ -1,0 +1,5 @@
+- [x] Document data-container re-seeding and per-note popover capture in SIMULATOR_E2E (issue #287, PR #296)
+  - `simctl install` swaps the data container even with no parallel session, so the seed
+    has to come after the final install with the path re-queried
+  - `openurl` + a tap on the launch-visible control panel captures a chosen note's info
+    popover; used for the four states in issue #267


### PR DESCRIPTION
Closes #287

Two notes from verifying #267 entirely from the command line, added to
`docs/SIMULATOR_E2E.md`:

- **Seeding**: the existing warning about the data container being "replaced under you"
  reads as a parallel-session hazard only. It also happens on a dedicated simulator with
  no other session running — `get_app_container` returns a different path after
  `simctl install`, and the earlier seed belongs to the old container. The section now
  says to seed after the final install and re-query the path each time, and names the
  symptom (an empty note list that looks like a load failure).
- **`openurl`**: seeding, `openurl`, and the launch-visible control panel were documented
  separately; the section now says they compose into per-note UI verification — `openurl`
  a seeded note, then tap Note Information to capture that note's popover.

Docs only, no code change.
