### PR TITLE
Document that the first idb gesture after launch is dropped

### DIFF
--- a/docs/SIMULATOR_E2E.md
+++ b/docs/SIMULATOR_E2E.md
@@ -181,6 +181,11 @@ way, with no gesture injection.
   the picker's ⋯ menu is open closes the menu and draws nothing, which reads as "drawing is
   broken" — the same swipe repeated draws normally. Check `describe-all` for the menu rows before
   operating, and assert state both before and after each injection.
+- **The first gesture after `simctl launch` is dropped too**: a `ui swipe` sent right after launch
+  leaves the canvas empty even though `describe-all` already lists the control panel and the
+  picker; the next identical swipe draws. Two swipes issued in one shell command are both lost, so
+  the retry has to be a separate injection. Seen while comparing pen state across two builds, where
+  it first looked like the build under test had broken drawing. Background: PR #295.
 - **Sidebar pages**: to land directly on Quick Tutorial, Setting or Tag List, change the
   initial `selection` in `RootSplitView` to that page (e.g. `.tutorial`) in a throwaway
   build. The `selection` change alone does not keep the canvas away — `sceneDidBecomeActive`

--- a/docs/progress/2026-07-26-simulator-e2e-launch-gesture.md
+++ b/docs/progress/2026-07-26-simulator-e2e-launch-gesture.md
@@ -1,0 +1,2 @@
+- [x] Document that the first idb gesture after launch is dropped (issue #300, PR #301)
+  - A `ui swipe` right after `simctl launch` draws nothing although `describe-all` already lists the chrome, and two swipes in one shell command are both lost; the retry has to be a separate injection


### PR DESCRIPTION
Closes #300

Adds one Limitations entry to `docs/SIMULATOR_E2E.md`: a `ui swipe` sent right after `simctl launch` is dropped even though `describe-all` already lists the chrome, and two swipes in one shell command are both lost — the retry has to be a separate injection. Found while comparing pen state across two builds for PR #295, where it first looked like the build under test had broken drawing.

The neighbouring entry covers the same misreading for the menu-dismissal case; this is a different trigger.

Docs only, no code changes.