### PR TITLE
Bump the version to 4.0.0 (build 30)

### DIFF
--- a/PiecesOfPaper.xcodeproj/project.pbxproj
+++ b/PiecesOfPaper.xcodeproj/project.pbxproj
@@ -596,7 +596,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = PiecesOfPaper/PiecesOfPaper.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = PiecesOfPaper/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -604,7 +604,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper;
 				PRODUCT_NAME = "Pieces of Paper";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -622,7 +622,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = PiecesOfPaper/PiecesOfPaper.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = PiecesOfPaper/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -630,7 +630,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper;
 				PRODUCT_NAME = "Pieces of Paper";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -645,7 +645,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = ThumbnailExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -654,7 +654,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.ThumbnailExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -670,7 +670,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = ThumbnailExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -679,7 +679,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.ThumbnailExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -695,7 +695,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -704,7 +704,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.PreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = JDTR4Y333X;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -729,7 +729,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 4.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Individual.LikeAPaper.PreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/docs/progress/2026-07-26-release-4-0-0.md
+++ b/docs/progress/2026-07-26-release-4-0-0.md
@@ -1,0 +1,4 @@
+- [x] Bump the version to 4.0.0 and the build number to 30 for the App Store submission (issue #303, PR #304)
+  - Build number jumps 18 → 30 because App Store Connect's last uploaded build is 29; the value tracked in the repository had drifted from what was actually shipped
+  - `scripts/bump-version.sh` rewrites every build configuration in one pass, keeping the app and both QuickLook extensions on the same version and build
+  - 4.0.0 rather than 3.4.0: the minimum iOS goes 17.0 → 18.0, and notes are renamed `.plist` → `.pop`, which hides them from a device still running 3.3.0 against the same iCloud container until that device is updated


### PR DESCRIPTION
Sets the version for the 4.0.0 submission.

- `MARKETING_VERSION`: 3.3.0 → 4.0.0
- `CURRENT_PROJECT_VERSION`: 18 → 30 (App Store Connect's last uploaded build is 29; the value in the repository had drifted)

`scripts/bump-version.sh set 4.0.0` and `set-build 30` rewrite every build configuration at once, so the app and both QuickLook extensions carry the same version and build — a mismatch between them is rejected at upload.

Only `project.pbxproj` changes: 12 lines across the 6 build configurations that declare these keys (app, ThumbnailExtension, PreviewExtension × Debug/Release). No source, no behavior change. `xcodebuild -showBuildSettings` still parses the project and reports 4.0.0 / 30.

Closes #303
