### PR TITLE
Document the FilePath layering exception

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -3,6 +3,12 @@
 Pitfalls encountered during development, split out of [CLAUDE.md](../CLAUDE.md).
 Each entry links to the issue/PR where the details live.
 
+## Architecture / layering
+
+The app is View + Store + Repository + Model, with dependencies running one way: View sees only Stores (through `@Environment`), Stores take Repository protocols by injection, Repositories use Model types. `RootSplitView` owns the three Stores and injects them. ViewModels were removed in PR #186.
+
+- **`FilePath` reading the iCloud preference directly is a deliberate exception**: `FilePath.isiCloudActive` constructs a `PreferenceRepository()` inline, so a Model type depends on the Repository layer — and since `NoteRepository` and `TagRepository` depend on `FilePath` for path resolution, that closes a `Model → Repository → Model` cycle. It is the only remaining inversion. Don't "fix" it by reflex: unlike the canvas case (issue #269), where `PKCanvasViewWrapper` already accepted closures from the SwiftUI side and the fix was two closures, there is no cheap seam here. `FilePath` is an `enum` namespace of static computed properties called with no arguments from pure value types (`NoteData`, `NoteIndexEntry`) and from tests, so parameterizing it by storage mode means touching every path property and roughly thirty call sites. The pull-based shape also has a property the alternatives lose: the flag is read at access time, so there is no seeding step to forget and no ordering hazard. Two costs to know about — tests that build URLs from `FilePath.inboxUrl` depend implicitly on whatever the flag returns in the test process, and `savingUrl` and `noteMetadataCacheFileUrl` read it separately, so the cache filename suffix and the directory in use are not resolved atomically (not reproduced, but nothing rules it out). Background: issue #308.
+
 ## PencilKit / Canvas
 
 - **Never call `PKDrawing.image(from:scale:)` off the main actor**: calling it even once from a background context (e.g. `Task.detached`) breaks `PKCanvasView` stroke rendering process-wide — the Pencil stops drawing and existing notes render blank. Device-only; the Simulator and unit tests cannot reproduce it. Render thumbnails via `MainActor.run`. Details: issue #187, PR #189.

--- a/docs/progress/2026-07-26-docs-filepath-preference-gotcha.md
+++ b/docs/progress/2026-07-26-docs-filepath-preference-gotcha.md
@@ -1,0 +1,13 @@
+- [x] Record the FilePath layering exception instead of resolving it (issue #308, PR #310)
+  - `docs/GOTCHAS.md` gains an "Architecture / layering" section: the one-way View + Store +
+    Repository + Model rule, plus why `FilePath.isiCloudActive` building a
+    `PreferenceRepository()` inline is accepted. It closes a `Model → Repository → Model` cycle
+    with `NoteRepository`/`TagRepository`, but `FilePath` is an `enum` of argument-less statics
+    reached from pure value types and tests, so parameterizing it by storage mode touches
+    roughly thirty call sites, and the pull-based read cannot go stale
+  - The accepted costs are written down too: tests that derive URLs from `FilePath.inboxUrl`
+    depend on whatever the flag returns in the test process, and `savingUrl` /
+    `noteMetadataCacheFileUrl` resolve it separately, so the cache filename suffix and the
+    directory in use are not atomic
+  - Contrast with the canvas equivalent (issue #269, PR #280) is recorded: that fix was cheap
+    only because `PKCanvasViewWrapper` already took closures from the SwiftUI side


### PR DESCRIPTION
Closes #308

## What

Adds an `Architecture / layering` section to `docs/GOTCHAS.md`: a short statement of the View + Store + Repository + Model rule, plus one entry recording that `FilePath.isiCloudActive` constructing a `PreferenceRepository()` directly is a known and accepted exception rather than an oversight.

No code changes.

## Why

#308 proposed resolving the `Model → Repository → Model` cycle. After walking the call sites, the cost/benefit did not hold up:

- `FilePath` is an `enum` namespace of static computed properties, called with no arguments from pure value types (`NoteData`, `NoteIndexEntry`) and from tests. Parameterizing it by storage mode means touching every path property and roughly thirty call sites.
- The current pull-based read cannot go stale: the flag is read at access time, so there is no seeding step to forget. Every alternative either introduces order-dependent global state in `FilePath` or duplicates the resolution between the Repository and Store layers.
- Unlike the canvas case (#269), there is no comparably cheap seam. That fix was two closures only because `PKCanvasViewWrapper` already accepted closures from the SwiftUI side.

So the decision is to leave the code as it is and make the reasoning discoverable, so it does not get "fixed" by reflex later.

The entry also records the two costs being accepted: tests that build URLs from `FilePath.inboxUrl` depend implicitly on whatever the flag returns in the test process, and `savingUrl` / `noteMetadataCacheFileUrl` read the flag separately, so the cache filename suffix and the directory in use are not resolved atomically (not reproduced; nothing rules it out).

## Verification

Documentation only, no behavior or build impact. `swiftlint` reports the same 12 pre-existing warnings as `origin/main` — no Swift files are touched.
