### PR TITLE
Add an in-app What's New page

### DIFF
--- a/PiecesOfPaper/Model/ReleaseNote.swift
+++ b/PiecesOfPaper/Model/ReleaseNote.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// One release's highlights, rendered as a section of the What's New page.
+struct ReleaseNote: Identifiable {
+    let version: String
+    let date: Date
+    let highlights: [LocalizedStringKey]
+
+    var id: String { version }
+}
+
+extension ReleaseNote {
+    static var latest: ReleaseNote? { all.first }
+
+    /// Newest first — the page renders this order, and `latest` drives the unread badge.
+    static let all: [ReleaseNote] = [
+        ReleaseNote(
+            version: "4.0.0",
+            date: date(year: 2026, month: 7, day: 27),
+            highlights: [
+                """
+                Your notes are files now. They show up in the Files app as drawing thumbnails, \
+                preview with the space bar, and open straight into Pieces of Paper to edit in place
+                """,
+                """
+                The canvas controls moved into a floating panel, tapping the paper hides them for \
+                a plain sheet, the share sheet opens from the panel, and Settings has a Light/Dark \
+                appearance option
+                """,
+                "Tags can be renamed and edited",
+                "The note list loads faster",
+                "Requires iPadOS 18",
+                """
+                Update Pieces of Paper on every device you use. A device still running 3.3.0 shows \
+                an empty note list until it is updated, and its notes come back once it is
+                """
+            ]
+        )
+    ]
+
+    // The calendar's time zone is the device's, so the day this produces is the day the
+    // page formats back out — fixing it to GMT would show the previous date west of it
+    private static func date(year: Int, month: Int, day: Int) -> Date {
+        Calendar(identifier: .gregorian)
+            .date(from: DateComponents(year: year, month: month, day: day)) ?? .distantPast
+    }
+}

--- a/PiecesOfPaper/Repository/PreferenceRepository.swift
+++ b/PiecesOfPaper/Repository/PreferenceRepository.swift
@@ -9,6 +9,8 @@ protocol PreferenceRepositoryProtocol {
     func setEnabledInfiniteScroll(_ value: Bool)
     func getAppearanceMode() -> AppearanceMode
     func setAppearanceMode(_ value: AppearanceMode)
+    func getLastSeenWhatsNewVersion() -> String?
+    func setLastSeenWhatsNewVersion(_ value: String)
     func getListOrder(directoryName: String) -> ListOrder
     func setListOrder(directoryName: String, listOrder: ListOrder)
 }
@@ -18,6 +20,7 @@ struct PreferenceRepository: PreferenceRepositoryProtocol {
     private let autoSaveDisabledKey = "autosave_disabled"
     private let infiniteScrollKey = "infinite_scroll_disabled"
     private let appearanceModeKey = "appearance_mode"
+    private let lastSeenWhatsNewVersionKey = "last_seen_whats_new_version"
     private let listOrderKey = "com.pop.listOrder."
 
     func getEnablediCloud() -> Bool {
@@ -54,6 +57,16 @@ struct PreferenceRepository: PreferenceRepositoryProtocol {
 
     func setAppearanceMode(_ value: AppearanceMode) {
         UserDefaults.standard.set(value.rawValue, forKey: appearanceModeKey)
+    }
+
+    // An absent key means the page has never been opened, which is what makes an
+    // upgrade from a version that predates it count as unread
+    func getLastSeenWhatsNewVersion() -> String? {
+        UserDefaults.standard.string(forKey: lastSeenWhatsNewVersionKey)
+    }
+
+    func setLastSeenWhatsNewVersion(_ value: String) {
+        UserDefaults.standard.set(value, forKey: lastSeenWhatsNewVersionKey)
     }
 
     func getListOrder(directoryName: String) -> ListOrder {

--- a/PiecesOfPaper/Store/PreferenceStore.swift
+++ b/PiecesOfPaper/Store/PreferenceStore.swift
@@ -32,6 +32,11 @@ final class PreferenceStore {
         }
     }
 
+    // Written through markWhatsNewSeen instead of the didSet the other preferences use:
+    // an optional is already initialized to nil before init runs, so the seeding
+    // assignment below counts as a mutation and would re-persist on every launch
+    private(set) var lastSeenWhatsNewVersion: String?
+
     // Stored, not computed: the system inputs (account, container URL) are not
     // observable, so views would never re-render on a computed property
     private(set) var cloudAvailability: CloudAvailability = .userDisabled
@@ -44,7 +49,20 @@ final class PreferenceStore {
         self.enabledAutoSave = repository.getEnabledAutoSave()
         self.enabledInfiniteScroll = repository.getEnabledInfiniteScroll()
         self.appearanceMode = repository.getAppearanceMode()
+        self.lastSeenWhatsNewVersion = repository.getLastSeenWhatsNewVersion()
         refreshCloudAvailability()
+    }
+
+    // Takes the version rather than reading ReleaseNote.all: the Store layer receives
+    // Model values through the repository, and the rule stays testable against
+    // orderings the shipped release list does not contain
+    func hasUnseenWhatsNew(latestVersion: String) -> Bool {
+        lastSeenWhatsNewVersion != latestVersion
+    }
+
+    func markWhatsNewSeen(version: String) {
+        lastSeenWhatsNewVersion = version
+        repository.setLastSeenWhatsNewVersion(version)
     }
 
     func refreshCloudAvailability() {

--- a/PiecesOfPaper/View/Bullet.swift
+++ b/PiecesOfPaper/View/Bullet.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct Bullet: View {
+    private let text: LocalizedStringKey
+
+    init(_ text: LocalizedStringKey) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("•")
+                .foregroundStyle(.secondary)
+            Text(text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/PiecesOfPaper/View/Root/RootSplitView.swift
+++ b/PiecesOfPaper/View/Root/RootSplitView.swift
@@ -11,6 +11,7 @@ struct RootSplitView: View {
     private enum Page: String, CaseIterable {
         case inbox, trash
         case tag
+        case whatsNew
         case tutorial
         case setting
 
@@ -19,6 +20,7 @@ struct RootSplitView: View {
             case .inbox: "Inbox"
             case .trash: "Trash"
             case .tag: "Tag List"
+            case .whatsNew: "What's New"
             case .tutorial: "Quick Tutorial"
             case .setting: "Setting"
             }
@@ -36,6 +38,8 @@ struct RootSplitView: View {
                 NoteListScreen(directory: .archived)
             case .tag:
                 TagList()
+            case .whatsNew:
+                WhatsNewView()
             case .tutorial:
                 TutorialView()
             case .setting:
@@ -134,6 +138,16 @@ struct RootSplitView: View {
                 }
             }
             Section(header: Text("Tutorial")) {
+                NavigationLink(value: Page.whatsNew) {
+                    HStack {
+                        Label(Page.whatsNew.label, systemImage: "sparkles")
+                        if let latest = ReleaseNote.latest,
+                           preferenceStore.hasUnseenWhatsNew(latestVersion: latest.version) {
+                            Spacer()
+                            unreadDot
+                        }
+                    }
+                }
                 NavigationLink(value: Page.tutorial) {
                     Label(Page.tutorial.label, systemImage: "text.document")
                 }
@@ -145,6 +159,13 @@ struct RootSplitView: View {
             }
         }
         .navigationTitle("Pieces of Paper")
+    }
+
+    private var unreadDot: some View {
+        Circle()
+            .fill(.red)
+            .frame(width: 8, height: 8)
+            .accessibilityLabel("New")
     }
 }
 

--- a/PiecesOfPaper/View/SectionHeader.swift
+++ b/PiecesOfPaper/View/SectionHeader.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct SectionHeader: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.title2.bold())
+    }
+}

--- a/PiecesOfPaper/View/Tutorial/TutorialView.swift
+++ b/PiecesOfPaper/View/Tutorial/TutorialView.swift
@@ -162,33 +162,6 @@ struct TutorialView: View {
     }
 }
 
-private struct SectionHeader: View {
-    let title: LocalizedStringKey
-    let systemImage: String
-
-    var body: some View {
-        Label(title, systemImage: systemImage)
-            .font(.title2.bold())
-    }
-}
-
-private struct Bullet: View {
-    private let text: LocalizedStringKey
-
-    init(_ text: LocalizedStringKey) {
-        self.text = text
-    }
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text("•")
-                .foregroundStyle(.secondary)
-            Text(text)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-}
-
 private struct FAQItem: View {
     let question: LocalizedStringKey
     let answer: LocalizedStringKey

--- a/PiecesOfPaper/View/WhatsNew/WhatsNewView.swift
+++ b/PiecesOfPaper/View/WhatsNew/WhatsNewView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct WhatsNewView: View {
+    @Environment(PreferenceStore.self) private var preferenceStore
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 32) {
+                ForEach(Array(ReleaseNote.all.enumerated()), id: \.element.id) { index, note in
+                    if index > 0 {
+                        Divider()
+                    }
+                    release(note)
+                }
+            }
+            .frame(maxWidth: 720, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding()
+        }
+        // Reaching this body is the whole gate: `RootSplitView.selection` is plain
+        // @State with no restoration, so the page cannot be showing without the user
+        // having picked it. Persisting the selection would break that assumption
+        .onAppear {
+            guard let latest = ReleaseNote.latest else { return }
+            preferenceStore.markWhatsNewSeen(version: latest.version)
+        }
+    }
+
+    private func release(_ note: ReleaseNote) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionHeader(title: "Version \(note.version)", systemImage: "sparkles")
+            Text(note.date.formatted(date: .long, time: .omitted))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            ForEach(Array(note.highlights.enumerated()), id: \.offset) { _, highlight in
+                Bullet(highlight)
+            }
+        }
+    }
+}
+
+#Preview {
+    WhatsNewView()
+        .environment(PreferenceStore())
+}

--- a/PiecesOfPaperTests/PreferenceRepositoryMock.swift
+++ b/PiecesOfPaperTests/PreferenceRepositoryMock.swift
@@ -6,11 +6,13 @@ final class PreferenceRepositoryMock: PreferenceRepositoryProtocol {
     var enabledAutoSave = true
     var enabledInfiniteScroll = true
     var appearanceMode: AppearanceMode = .system
+    var lastSeenWhatsNewVersion: String?
     var listOrders: [String: ListOrder] = [:]
     private(set) var setEnablediCloudCalls: [Bool] = []
     private(set) var setEnabledAutoSaveCalls: [Bool] = []
     private(set) var setEnabledInfiniteScrollCalls: [Bool] = []
     private(set) var setAppearanceModeCalls: [AppearanceMode] = []
+    private(set) var setLastSeenWhatsNewVersionCalls: [String] = []
     private(set) var setListOrderCalls: [(directoryName: String, listOrder: ListOrder)] = []
 
     func getEnablediCloud() -> Bool { enablediCloud }
@@ -39,6 +41,13 @@ final class PreferenceRepositoryMock: PreferenceRepositoryProtocol {
     func setAppearanceMode(_ value: AppearanceMode) {
         appearanceMode = value
         setAppearanceModeCalls.append(value)
+    }
+
+    func getLastSeenWhatsNewVersion() -> String? { lastSeenWhatsNewVersion }
+
+    func setLastSeenWhatsNewVersion(_ value: String) {
+        lastSeenWhatsNewVersion = value
+        setLastSeenWhatsNewVersionCalls.append(value)
     }
 
     func getListOrder(directoryName: String) -> ListOrder {

--- a/PiecesOfPaperTests/PreferenceStoreTests.swift
+++ b/PiecesOfPaperTests/PreferenceStoreTests.swift
@@ -9,16 +9,19 @@ struct PreferenceStoreTests {
         mock.enabledAutoSave = false
         mock.enabledInfiniteScroll = false
         mock.appearanceMode = .dark
+        mock.lastSeenWhatsNewVersion = "4.0.0"
 
         let store = PreferenceStore(repository: mock)
         #expect(store.enablediCloud)
         #expect(!store.enabledAutoSave)
         #expect(!store.enabledInfiniteScroll)
         #expect(store.appearanceMode == .dark)
+        #expect(store.lastSeenWhatsNewVersion == "4.0.0")
         #expect(mock.setEnablediCloudCalls.isEmpty)
         #expect(mock.setEnabledAutoSaveCalls.isEmpty)
         #expect(mock.setEnabledInfiniteScrollCalls.isEmpty)
         #expect(mock.setAppearanceModeCalls.isEmpty)
+        #expect(mock.setLastSeenWhatsNewVersionCalls.isEmpty)
     }
 
     @Test func test_enablediCloud_persistsOnChange() {
@@ -51,6 +54,44 @@ struct PreferenceStoreTests {
         store.appearanceMode = .light
         #expect(mock.setAppearanceModeCalls == [.light])
         #expect(mock.getAppearanceMode() == .light)
+    }
+
+    @Test func test_markWhatsNewSeen_persistsTheVersion() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        store.markWhatsNewSeen(version: "4.0.0")
+        #expect(store.lastSeenWhatsNewVersion == "4.0.0")
+        #expect(mock.setLastSeenWhatsNewVersionCalls == ["4.0.0"])
+        #expect(mock.getLastSeenWhatsNewVersion() == "4.0.0")
+    }
+
+    @Test func test_markWhatsNewSeen_clearsTheUnseenFlag() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        #expect(store.hasUnseenWhatsNew(latestVersion: "4.0.0"))
+        store.markWhatsNewSeen(version: "4.0.0")
+        #expect(!store.hasUnseenWhatsNew(latestVersion: "4.0.0"))
+    }
+
+    // An absent key is what an upgrade from a version without the page looks like
+    @Test func test_hasUnseenWhatsNew_isTrue_whenNothingSeenYet() {
+        let mock = PreferenceRepositoryMock()
+        let store = PreferenceStore(repository: mock)
+        #expect(store.hasUnseenWhatsNew(latestVersion: "4.0.0"))
+    }
+
+    @Test func test_hasUnseenWhatsNew_isFalse_whenLatestAlreadySeen() {
+        let mock = PreferenceRepositoryMock()
+        mock.lastSeenWhatsNewVersion = "4.0.0"
+        let store = PreferenceStore(repository: mock)
+        #expect(!store.hasUnseenWhatsNew(latestVersion: "4.0.0"))
+    }
+
+    @Test func test_hasUnseenWhatsNew_isTrue_whenOnlyAnOlderVersionSeen() {
+        let mock = PreferenceRepositoryMock()
+        mock.lastSeenWhatsNewVersion = "4.0.0"
+        let store = PreferenceStore(repository: mock)
+        #expect(store.hasUnseenWhatsNew(latestVersion: "4.1.0"))
     }
 
     @Test func test_cloudAvailability_isUserDisabled_wheniCloudToggleOff() {

--- a/PiecesOfPaperTests/ReleaseNoteTests.swift
+++ b/PiecesOfPaperTests/ReleaseNoteTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import Pieces_of_Paper
+
+struct ReleaseNoteTests {
+    // `latest` is what the unread badge compares against, so an empty list would
+    // silently mean "nothing is ever new"
+    @Test func test_latest_isPresent() {
+        #expect(ReleaseNote.latest != nil)
+    }
+
+    @Test func test_all_isOrderedNewestFirst() {
+        let versions = ReleaseNote.all.map(\.version)
+        let sorted = versions.sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+        #expect(versions == sorted)
+    }
+
+    // The version doubles as the identity and as the seen-marker persisted in
+    // PreferenceStore, so a duplicate would make the unread badge unresolvable
+    @Test func test_versions_areUnique() {
+        #expect(Set(ReleaseNote.all.map(\.version)).count == ReleaseNote.all.count)
+    }
+
+    @Test func test_everyEntry_hasHighlights() {
+        for note in ReleaseNote.all {
+            #expect(!note.highlights.isEmpty)
+        }
+    }
+
+    @Test func test_dates_areRealCalendarDates() {
+        for note in ReleaseNote.all {
+            #expect(note.date != .distantPast)
+        }
+    }
+}

--- a/docs/progress/2026-07-27-whats-new-page.md
+++ b/docs/progress/2026-07-27-whats-new-page.md
@@ -1,0 +1,6 @@
+- [x] Add an in-app What's New page that accumulates release highlights (issue #319, PR #323)
+  - The page, not a launch modal: a sheet at the root would sit under the blank canvas `fullScreenCover` that `sceneDidBecomeActive` opens, the same failure as the alert entry in GOTCHAS
+  - `ReleaseNote.all` is the newest-first source for both the page and the unread marker; the shipped `MARKETING_VERSION` is deliberately not consulted, so a patch release with no entry raises no marker
+  - `PreferenceStore.hasUnseenWhatsNew(latestVersion:)` takes the version as an argument rather than reading `ReleaseNote.all`, keeping the Store's Model access on the repository path and the rule testable against orderings the shipped list does not contain
+  - The seen marker is written by `markWhatsNewSeen(version:)`, not a `didSet`: an optional stored property is initialized to `nil` before `init` runs, so under `@Observable` the seeding assignment counts as a mutation and re-persists on every launch (`test_init_readsValuesWithoutRePersisting` caught it)
+  - `SectionHeader` and `Bullet` left `TutorialView` for shared files so both pages share one style


### PR DESCRIPTION
Closes #319

The 4.0.0 headline — notes are real files, visible in the Files app with thumbnails and previews and editable in place — cannot be discovered from inside the app: the note list looks exactly like 3.3.0's. App Store release notes do not close that gap because updates install automatically.

A **What's New** page now sits in the sidebar's Tutorial section, above Quick Tutorial, holding one section per release, newest first. Later releases append an entry rather than replacing the page.

## What changed

**A `ReleaseNote` model** (`PiecesOfPaper/Model/ReleaseNote.swift`) carries a version, a date and the highlight bullets. `all` is the newest-first list the page renders and `latest` is what the unread marker compares against — the shipped `MARKETING_VERSION` is deliberately not consulted, so a patch release with no entry raises no marker. `ReleaseNoteTests` pins the invariants the page depends on: the list is ordered newest first, versions are unique, and every entry has highlights and a real calendar date.

**The seen marker is persisted** as `last_seen_whats_new_version` through `PreferenceRepository`, in the same string-keyed shape as `appearance_mode`, and an absent key counts as unseen — so anyone upgrading from 3.3.0 gets the marker, and a fresh install showing it once is accepted. `PreferenceStore.hasUnseenWhatsNew(latestVersion:)` takes the version as an argument instead of reading `ReleaseNote.all`: the Store layer receives Model values through its repository, and the rule stays testable against orderings the shipped list does not contain.

`markWhatsNewSeen(version:)` writes it explicitly rather than through the `didSet` the other preferences use. An optional stored property is already initialized to `nil` before `init` runs, so under `@Observable` the seeding assignment in `init` counts as a mutation and a `didSet` would re-persist on every launch — `test_init_readsValuesWithoutRePersisting` caught exactly that.

**The unread marker is a red dot**, not `.badge()`, with `accessibilityLabel("New")` so VoiceOver announces the row as "What's New, New".

**`SectionHeader` and `Bullet` moved out of `TutorialView`** into `PiecesOfPaper/View/SectionHeader.swift` and `Bullet.swift` (they were `private`), so both pages share one style. `FAQItem` stays private to the tutorial. No behaviour change — this is the first commit on its own.

## Behaviour and appearance flags

- **New sidebar row** in the Tutorial section, so that section now has two rows.
- **A red dot appears for every existing user on first launch after this ships**, and clears the first time the page is opened.
- The Quick Tutorial page is untouched in content and rendering; only where its two helper views are declared changed.

## Verification

`swiftlint` reports 0 violations. `xcodebuild test` passes with 205 tests in 32 suites — 10 more than the 195 on this branch's base, and each new test name appears in the run.

Simulator E2E on a dedicated iPad Pro 11-inch (M4) / iOS 26.5 device, Debug build, clean install, both directions of the marker measured with `idb ui describe-point` on the row rather than by eye:

| Step | Result |
|-|-|
| Clean install, first launch, sidebar opened | Row reads `What's New, New`; red dot visible in the screenshot |
| What's New tapped | Version 4.0.0 section renders with its date and six bullets |
| Row re-probed immediately after | Row reads `What's New` — marker cleared |
| App terminated and relaunched | Row still reads `What's New`, and `Library/Preferences/Individual.LikeAPaper.plist` holds `last_seen_whats_new_version => 4.0.0` |
| Quick Tutorial opened | Renders as before the extraction |

Note `xcrun simctl spawn … defaults read` reports the key as missing even after the app is terminated; the plist in the app container is the reliable read (the `defaults`/cfprefsd caveat in `docs/SIMULATOR_E2E.md`).

No device verification: nothing here touches the canvas, PencilKit or thumbnail rendering.

## Before merge

The 4.0.0 entry is dated **July 27, 2026**. If the App Store release date moves, update `ReleaseNote.all`'s date before merging — the page prints it verbatim.

## Not in scope

Any alert or other active notice for the note conversion (#321, closed — the multi-device line here and the App Store release notes in #303 carry it), entries for 1.0.0–3.3.0, any launch-time modal, and localization (#273 — the new page takes `LocalizedStringKey` like the tutorial, so it is ready for it).

## Overlap with #305

#305 rewrites `TutorialView`'s body and renames sidebar section headers. It does not touch the two helper views this PR moves, and this PR does not touch the tutorial's copy, so the two should merge cleanly; whichever lands second gets a re-run of the build and tests.
